### PR TITLE
0.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.DS_Store
 *.log
 *.profraw
+/.idea/
+/.idea/
 /.vscode/
 /build.rs
 /rust-toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ deprecated_in_future = "deny"
 ellipsis_inclusive_range_patterns = "deny"
 explicit_outlives_requirements = "deny"
 future_incompatible = { level = "deny", priority = -1 }
-keyword_idents = "deny"
+keyword_idents = { level = "deny", priority = -1 }
 macro_use_extern_crate = "deny"
 meta_variable_misuse = "deny"
 missing_fragment_specifier = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "libyml"
 readme = "README.md"
 repository = "https://github.com/sebastienrousseau/libyml"
 rust-version = "1.60"
-version = "0.0.3"
+version = "0.0.4"
 
 # Included and excluded files
 include = [

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ cargo run --example apis
 [09]: https://codecov.io/gh/sebastienrousseau/libyml
 [10]: https://github.com/sebastienrousseau/libyml/actions?query=branch%3Amaster
 [build-badge]: https://img.shields.io/github/actions/workflow/status/sebastienrousseau/libyml/release.yml?branch=master&style=for-the-badge&logo=github
-[codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&token=Q9KJ6XXL67&logo=codecov
+[codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&token=yc9s578xIk&logo=codecov
 [crates-badge]: https://img.shields.io/crates/v/libyml.svg?style=for-the-badge&color=fc8d62&logo=rust
 [libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.3-orange.svg?style=for-the-badge
 [docs-badge]: https://img.shields.io/badge/docs.rs-libyml-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ contributions to the Rust and C programming communities.
 
 ```toml
 [dependencies]
-libyml = "0.0.3"
+libyml = "0.0.4"
 ```
 
 Release notes are available under [GitHub releases][05].
@@ -143,6 +143,6 @@ cargo run --example apis
 [build-badge]: https://img.shields.io/github/actions/workflow/status/sebastienrousseau/libyml/release.yml?branch=master&style=for-the-badge&logo=github
 [codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&token=yc9s578xIk&logo=codecov
 [crates-badge]: https://img.shields.io/crates/v/libyml.svg?style=for-the-badge&color=fc8d62&logo=rust
-[libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.3-orange.svg?style=for-the-badge
+[libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.4-orange.svg?style=for-the-badge
 [docs-badge]: https://img.shields.io/badge/docs.rs-libyml-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs
 [github-badge]: https://img.shields.io/badge/github-sebastienrousseau/libyml-8da0cb?style=for-the-badge&labelColor=555555&logo=github

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ cargo run --example apis
 [09]: https://codecov.io/gh/sebastienrousseau/libyml
 [10]: https://github.com/sebastienrousseau/libyml/actions?query=branch%3Amaster
 [build-badge]: https://img.shields.io/github/actions/workflow/status/sebastienrousseau/libyml/release.yml?branch=master&style=for-the-badge&logo=github
-[codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&token=yc9s578xIk&logo=codecov
+[codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&logo=codecov&token=yc9s578xIk
 [crates-badge]: https://img.shields.io/crates/v/libyml.svg?style=for-the-badge&color=fc8d62&logo=rust
 [libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.4-orange.svg?style=for-the-badge
 [docs-badge]: https://img.shields.io/badge/docs.rs-libyml-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -65,7 +65,7 @@ This library is compatible with Rust 1.60 and above.
 [09]: https://codecov.io/gh/sebastienrousseau/libyml
 [10]: https://github.com/sebastienrousseau/libyml/actions?query=branch%3Amaster
 [build-badge]: https://img.shields.io/github/actions/workflow/status/sebastienrousseau/libyml/release.yml?branch=master&style=for-the-badge&logo=github
-[codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&token=Q9KJ6XXL67&logo=codecov
+[codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&token=yc9s578xIk&logo=codecov
 [crates-badge]: https://img.shields.io/crates/v/libyml.svg?style=for-the-badge&color=fc8d62&logo=rust
 [libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.3-orange.svg?style=for-the-badge
 [docs-badge]: https://img.shields.io/badge/docs.rs-libyml-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -40,7 +40,7 @@ contributions to the Rust and C programming communities.
 
 ```toml
 [dependencies]
-libyml = "0.0.3"
+libyml = "0.0.4"
 ```
 
 Release notes are available under [GitHub releases][05].
@@ -67,7 +67,7 @@ This library is compatible with Rust 1.60 and above.
 [build-badge]: https://img.shields.io/github/actions/workflow/status/sebastienrousseau/libyml/release.yml?branch=master&style=for-the-badge&logo=github
 [codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&token=yc9s578xIk&logo=codecov
 [crates-badge]: https://img.shields.io/crates/v/libyml.svg?style=for-the-badge&color=fc8d62&logo=rust
-[libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.3-orange.svg?style=for-the-badge
+[libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.4-orange.svg?style=for-the-badge
 [docs-badge]: https://img.shields.io/badge/docs.rs-libyml-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs
 [github-badge]: https://img.shields.io/badge/github-sebastienrousseau/libyml-8da0cb?style=for-the-badge&labelColor=555555&logo=github
 

--- a/examples/apis/main.rs
+++ b/examples/apis/main.rs
@@ -1,10 +1,11 @@
 #![allow(missing_docs)]
 pub(crate) use core::primitive::u8 as yaml_char_t;
 use libyml::api::{
-    yaml_free, yaml_malloc, yaml_parser_delete, yaml_parser_initialize,
+    yaml_free, yaml_parser_delete, yaml_parser_initialize,
     yaml_parser_set_input_string, yaml_realloc, yaml_strdup,
     yaml_string_extend, yaml_string_join,
 };
+use libyml::memory::yaml_malloc;
 
 use core::mem::MaybeUninit;
 use core::ptr;

--- a/examples/apis/main.rs
+++ b/examples/apis/main.rs
@@ -1,12 +1,11 @@
 #![allow(missing_docs)]
 pub(crate) use core::primitive::u8 as yaml_char_t;
 use libyml::api::{
-    yaml_free, yaml_parser_delete, yaml_parser_initialize,
+    yaml_parser_delete, yaml_parser_initialize,
     yaml_parser_set_input_string, yaml_strdup,
     yaml_string_extend, yaml_string_join,
 };
-use libyml::memory::{yaml_malloc,yaml_realloc};
-
+use libyml::memory::{yaml_free, yaml_malloc, yaml_realloc};
 use core::mem::MaybeUninit;
 use core::ptr;
 

--- a/examples/apis/main.rs
+++ b/examples/apis/main.rs
@@ -2,10 +2,10 @@
 pub(crate) use core::primitive::u8 as yaml_char_t;
 use libyml::api::{
     yaml_free, yaml_parser_delete, yaml_parser_initialize,
-    yaml_parser_set_input_string, yaml_realloc, yaml_strdup,
+    yaml_parser_set_input_string, yaml_strdup,
     yaml_string_extend, yaml_string_join,
 };
-use libyml::memory::yaml_malloc;
+use libyml::memory::{yaml_malloc,yaml_realloc};
 
 use core::mem::MaybeUninit;
 use core::ptr;

--- a/examples/apis/main.rs
+++ b/examples/apis/main.rs
@@ -1,13 +1,15 @@
 #![allow(missing_docs)]
+use core::mem::MaybeUninit;
 pub(crate) use core::primitive::u8 as yaml_char_t;
+use core::ptr;
 use libyml::api::{
     yaml_parser_delete, yaml_parser_initialize,
-    yaml_parser_set_input_string, yaml_strdup,
-    yaml_string_extend, yaml_string_join,
+    yaml_parser_set_input_string,
 };
-use libyml::memory::{yaml_free, yaml_malloc, yaml_realloc};
-use core::mem::MaybeUninit;
-use core::ptr;
+use libyml::memory::{
+    yaml_free, yaml_malloc, yaml_realloc, yaml_strdup,
+};
+use libyml::string::{yaml_string_extend, yaml_string_join};
 
 pub(crate) fn main() {
     // Print a message to indicate the file being executed.

--- a/examples/apis/main.rs
+++ b/examples/apis/main.rs
@@ -2,10 +2,8 @@
 use core::mem::MaybeUninit;
 pub(crate) use core::primitive::u8 as yaml_char_t;
 use core::ptr;
-use libyml::api::{
-    yaml_parser_delete, yaml_parser_initialize,
-    yaml_parser_set_input_string,
-};
+use libyml::api::yaml_parser_set_input_string;
+use libyml::decode::{yaml_parser_delete, yaml_parser_initialize};
 use libyml::memory::{
     yaml_free, yaml_malloc, yaml_realloc, yaml_strdup,
 };

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,7 @@
 use crate::externs::{
-    free, malloc, memcpy, memmove, memset, realloc, strdup, strlen,
+    free, memcpy, memmove, memset, strdup, strlen,
 };
-use crate::memory::yaml_malloc;
+use crate::memory::{yaml_malloc,yaml_realloc};
 use crate::ops::{ForceAdd as _, ForceMul as _};
 use crate::success::{Success, FAIL, OK};
 use crate::yaml::{size_t, yaml_char_t};
@@ -26,51 +26,6 @@ const INPUT_RAW_BUFFER_SIZE: usize = 16384;
 const INPUT_BUFFER_SIZE: usize = INPUT_RAW_BUFFER_SIZE * 3;
 const OUTPUT_BUFFER_SIZE: usize = 16384;
 const OUTPUT_RAW_BUFFER_SIZE: usize = OUTPUT_BUFFER_SIZE * 2 + 2;
-
-// /// Allocate memory using the system's `malloc` function.
-// ///
-// /// This function is a thin wrapper around the system's `malloc` function,
-// /// used for memory allocation within the LibYML crate.
-// ///
-// /// # Safety
-// ///
-// /// - This function is unsafe because it directly calls the system's `malloc` function,
-// ///   which can lead to undefined behaviour if misused.
-// /// - The caller must ensure that the requested size is valid and does not overflow.
-// /// - The caller is responsible for properly freeing the allocated memory using
-// ///   the corresponding `yaml_free` function when it is no longer needed.
-// ///
-// pub unsafe fn yaml_malloc(size: size_t) -> *mut libc::c_void {
-//     malloc(size)
-// }
-
-/// Reallocate memory using the system's `realloc` function.
-///
-/// This function is a thin wrapper around the system's `realloc` function,
-/// used for memory reallocation within the LibYML crate.
-///
-/// # Safety
-///
-/// - This function is unsafe because it directly calls the system's `realloc` function,
-///   which can lead to undefined behaviour if misused.
-/// - The caller must ensure that the provided `ptr` is either a valid pointer returned
-///   by a previous call to `yaml_malloc` or `yaml_realloc`, or a null pointer.
-/// - The caller must ensure that the requested size is valid and does not overflow.
-/// - If `realloc` fails to reallocate the memory, it returns a null pointer, and the
-///   original memory block pointed to by `ptr` is left unchanged.
-/// - The caller is responsible for properly freeing the reallocated memory using
-///   the corresponding `yaml_free` function when it is no longer needed.
-///
-pub unsafe fn yaml_realloc(
-    ptr: *mut libc::c_void,
-    size: size_t,
-) -> *mut libc::c_void {
-    if !ptr.is_null() {
-        realloc(ptr, size)
-    } else {
-        malloc(size)
-    }
-}
 
 /// Free memory allocated by `yaml_malloc` or `yaml_realloc`.
 ///

--- a/src/api.rs
+++ b/src/api.rs
@@ -11,19 +11,17 @@ use crate::{
     YamlDocumentStartEvent, YamlDocumentT, YamlEmitterStateT,
     YamlEmitterT, YamlEncodingT, YamlEventT, YamlMappingEndEvent,
     YamlMappingNode, YamlMappingStartEvent, YamlMappingStyleT,
-    YamlMarkT, YamlNodeItemT, YamlNodePairT, YamlNodeT,
-    YamlParserStateT, YamlParserT, YamlReadHandlerT, YamlScalarEvent,
-    YamlScalarNode, YamlScalarStyleT, YamlScalarToken,
-    YamlSequenceEndEvent, YamlSequenceNode, YamlSequenceStartEvent,
-    YamlSequenceStyleT, YamlSimpleKeyT, YamlStreamEndEvent,
-    YamlStreamStartEvent, YamlTagDirectiveT, YamlTagDirectiveToken,
-    YamlTagToken, YamlTokenT, YamlVersionDirectiveT, YamlWriteHandlerT,
+    YamlMarkT, YamlNodeItemT, YamlNodePairT, YamlNodeT, YamlParserT,
+    YamlReadHandlerT, YamlScalarEvent, YamlScalarNode,
+    YamlScalarStyleT, YamlScalarToken, YamlSequenceEndEvent,
+    YamlSequenceNode, YamlSequenceStartEvent, YamlSequenceStyleT,
+    YamlStreamEndEvent, YamlStreamStartEvent, YamlTagDirectiveT,
+    YamlTagDirectiveToken, YamlTagToken, YamlTokenT,
+    YamlVersionDirectiveT, YamlWriteHandlerT,
 };
 use core::mem::{size_of, MaybeUninit};
 use core::ptr::{self, addr_of_mut};
 
-const INPUT_RAW_BUFFER_SIZE: usize = 16384;
-const INPUT_BUFFER_SIZE: usize = INPUT_RAW_BUFFER_SIZE * 3;
 const OUTPUT_BUFFER_SIZE: usize = 16384;
 const OUTPUT_RAW_BUFFER_SIZE: usize = OUTPUT_BUFFER_SIZE * 2 + 2;
 
@@ -132,74 +130,6 @@ pub unsafe fn yaml_queue_extend(
         ) as *mut libc::c_void;
         *head = *start;
     }
-}
-
-/// Initialize a parser.
-///
-/// This function creates a new parser object. An application is responsible
-/// for destroying the object using the yaml_parser_delete() function.
-///
-/// # Safety
-///
-/// - `parser` must be a valid, non-null pointer to an uninitialized `YamlParserT` struct.
-/// - The `YamlParserT` struct must be properly aligned and have the expected memory layout.
-/// - The caller is responsible for properly destroying the parser object using `yaml_parser_delete`.
-///
-pub unsafe fn yaml_parser_initialize(
-    parser: *mut YamlParserT,
-) -> Success {
-    __assert!(!parser.is_null());
-    memset(
-        parser as *mut libc::c_void,
-        0,
-        size_of::<YamlParserT>() as libc::c_ulong,
-    );
-    BUFFER_INIT!((*parser).raw_buffer, INPUT_RAW_BUFFER_SIZE);
-    BUFFER_INIT!((*parser).buffer, INPUT_BUFFER_SIZE);
-    QUEUE_INIT!((*parser).tokens, YamlTokenT);
-    STACK_INIT!((*parser).indents, libc::c_int);
-    STACK_INIT!((*parser).simple_keys, YamlSimpleKeyT);
-    STACK_INIT!((*parser).states, YamlParserStateT);
-    STACK_INIT!((*parser).marks, YamlMarkT);
-    STACK_INIT!((*parser).tag_directives, YamlTagDirectiveT);
-    OK
-}
-
-/// Destroy a parser.
-///
-/// This function frees all memory associated with a parser object, including
-/// any dynamically allocated buffers, tokens, and other data structures.
-///
-/// # Safety
-///
-/// - `parser` must be a valid, non-null pointer to a properly initialized `YamlParserT` struct.
-/// - The `YamlParserT` struct and its associated data structures must have been properly initialized and their memory allocated correctly.
-/// - The `YamlParserT` struct and its associated data structures must be properly aligned and have the expected memory layout.
-/// - After calling this function, the `parser` pointer should be considered invalid and should not be used again.
-///
-pub unsafe fn yaml_parser_delete(parser: *mut YamlParserT) {
-    __assert!(!parser.is_null());
-    BUFFER_DEL!((*parser).raw_buffer);
-    BUFFER_DEL!((*parser).buffer);
-    while !QUEUE_EMPTY!((*parser).tokens) {
-        yaml_token_delete(addr_of_mut!(DEQUEUE!((*parser).tokens)));
-    }
-    QUEUE_DEL!((*parser).tokens);
-    STACK_DEL!((*parser).indents);
-    STACK_DEL!((*parser).simple_keys);
-    STACK_DEL!((*parser).states);
-    STACK_DEL!((*parser).marks);
-    while !STACK_EMPTY!((*parser).tag_directives) {
-        let tag_directive = POP!((*parser).tag_directives);
-        yaml_free(tag_directive.handle as *mut libc::c_void);
-        yaml_free(tag_directive.prefix as *mut libc::c_void);
-    }
-    STACK_DEL!((*parser).tag_directives);
-    memset(
-        parser as *mut libc::c_void,
-        0,
-        size_of::<YamlParserT>() as libc::c_ulong,
-    );
 }
 
 unsafe fn yaml_string_read_handler(

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,7 @@
 use crate::externs::{
     free, malloc, memcpy, memmove, memset, realloc, strdup, strlen,
 };
+use crate::memory::yaml_malloc;
 use crate::ops::{ForceAdd as _, ForceMul as _};
 use crate::success::{Success, FAIL, OK};
 use crate::yaml::{size_t, yaml_char_t};
@@ -26,22 +27,22 @@ const INPUT_BUFFER_SIZE: usize = INPUT_RAW_BUFFER_SIZE * 3;
 const OUTPUT_BUFFER_SIZE: usize = 16384;
 const OUTPUT_RAW_BUFFER_SIZE: usize = OUTPUT_BUFFER_SIZE * 2 + 2;
 
-/// Allocate memory using the system's `malloc` function.
-///
-/// This function is a thin wrapper around the system's `malloc` function,
-/// used for memory allocation within the LibYML crate.
-///
-/// # Safety
-///
-/// - This function is unsafe because it directly calls the system's `malloc` function,
-///   which can lead to undefined behaviour if misused.
-/// - The caller must ensure that the requested size is valid and does not overflow.
-/// - The caller is responsible for properly freeing the allocated memory using
-///   the corresponding `yaml_free` function when it is no longer needed.
-///
-pub unsafe fn yaml_malloc(size: size_t) -> *mut libc::c_void {
-    malloc(size)
-}
+// /// Allocate memory using the system's `malloc` function.
+// ///
+// /// This function is a thin wrapper around the system's `malloc` function,
+// /// used for memory allocation within the LibYML crate.
+// ///
+// /// # Safety
+// ///
+// /// - This function is unsafe because it directly calls the system's `malloc` function,
+// ///   which can lead to undefined behaviour if misused.
+// /// - The caller must ensure that the requested size is valid and does not overflow.
+// /// - The caller is responsible for properly freeing the allocated memory using
+// ///   the corresponding `yaml_free` function when it is no longer needed.
+// ///
+// pub unsafe fn yaml_malloc(size: size_t) -> *mut libc::c_void {
+//     malloc(size)
+// }
 
 /// Reallocate memory using the system's `realloc` function.
 ///

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,9 @@
 use crate::{
-    externs::{memcpy, memmove, memset, strlen},
+    externs::{memcpy, memset, strlen},
+    internal::yaml_check_utf8,
     libc,
-    memory::{yaml_free, yaml_malloc, yaml_realloc, yaml_strdup},
-    ops::{ForceAdd as _, ForceMul as _},
+    memory::{yaml_free, yaml_malloc, yaml_strdup},
+    ops::ForceAdd as _,
     success::{Success, FAIL, OK},
     yaml::{size_t, yaml_char_t},
     PointerExt, YamlAliasEvent, YamlAliasToken, YamlAnchorToken,
@@ -24,113 +25,6 @@ use core::{
 
 const OUTPUT_BUFFER_SIZE: usize = 16384;
 const OUTPUT_RAW_BUFFER_SIZE: usize = OUTPUT_BUFFER_SIZE * 2 + 2;
-
-/// Extend a stack by reallocating and copying the existing data.
-///
-/// This function is used to grow a stack when more space is needed.
-///
-/// # Safety
-///
-/// - This function is unsafe because it directly calls the system's `realloc` function,
-///   which can lead to undefined behaviour if misused.
-/// - The caller must ensure that `start`, `top`, and `end` are valid pointers into the
-///   same allocated memory block.
-/// - The caller must ensure that the memory block being extended is large enough to
-///   accommodate the new size.
-/// - The caller is responsible for properly freeing the extended memory block using
-///   the corresponding `yaml_free` function when it is no longer needed.
-///
-pub unsafe fn yaml_stack_extend(
-    start: *mut *mut libc::c_void,
-    top: *mut *mut libc::c_void,
-    end: *mut *mut libc::c_void,
-) {
-    let new_start: *mut libc::c_void = yaml_realloc(
-        *start,
-        (((*end as *mut libc::c_char)
-            .c_offset_from(*start as *mut libc::c_char)
-            as libc::c_long)
-            .force_mul(2_i64)) as size_t,
-    );
-    *top = (new_start as *mut libc::c_char).wrapping_offset(
-        (*top as *mut libc::c_char)
-            .c_offset_from(*start as *mut libc::c_char)
-            as libc::c_long as isize,
-    ) as *mut libc::c_void;
-    *end = (new_start as *mut libc::c_char).wrapping_offset(
-        (((*end as *mut libc::c_char)
-            .c_offset_from(*start as *mut libc::c_char)
-            as libc::c_long)
-            .force_mul(2_i64)) as isize,
-    ) as *mut libc::c_void;
-    *start = new_start;
-}
-
-/// Extend a queue by reallocating and copying the existing data.
-///
-/// This function is used to grow a queue when more space is needed.
-///
-/// # Safety
-///
-/// - This function is unsafe because it directly calls the system's `realloc` and
-///   `memmove` functions, which can lead to undefined behaviour if misused.
-/// - The caller must ensure that `start`, `head`, `tail`, and `end` are valid pointers
-///   into the same allocated memory block.
-/// - The caller must ensure that the memory block being extended is large enough to
-///   accommodate the new size.
-/// - The caller is responsible for properly freeing the extended memory block using
-///   the corresponding `yaml_free` function when it is no longer needed.
-///
-pub unsafe fn yaml_queue_extend(
-    start: *mut *mut libc::c_void,
-    head: *mut *mut libc::c_void,
-    tail: *mut *mut libc::c_void,
-    end: *mut *mut libc::c_void,
-) {
-    if *start == *head && *tail == *end {
-        let new_start: *mut libc::c_void = yaml_realloc(
-            *start,
-            (((*end as *mut libc::c_char)
-                .c_offset_from(*start as *mut libc::c_char)
-                as libc::c_long)
-                .force_mul(2_i64)) as size_t,
-        );
-        *head = (new_start as *mut libc::c_char).wrapping_offset(
-            (*head as *mut libc::c_char)
-                .c_offset_from(*start as *mut libc::c_char)
-                as libc::c_long as isize,
-        ) as *mut libc::c_void;
-        *tail = (new_start as *mut libc::c_char).wrapping_offset(
-            (*tail as *mut libc::c_char)
-                .c_offset_from(*start as *mut libc::c_char)
-                as libc::c_long as isize,
-        ) as *mut libc::c_void;
-        *end = (new_start as *mut libc::c_char).wrapping_offset(
-            (((*end as *mut libc::c_char)
-                .c_offset_from(*start as *mut libc::c_char)
-                as libc::c_long)
-                .force_mul(2_i64)) as isize,
-        ) as *mut libc::c_void;
-        *start = new_start;
-    }
-    if *tail == *end {
-        if *head != *tail {
-            memmove(
-                *start,
-                *head,
-                (*tail as *mut libc::c_char)
-                    .c_offset_from(*head as *mut libc::c_char)
-                    as libc::c_ulong,
-            );
-        }
-        *tail = (*start as *mut libc::c_char).wrapping_offset(
-            (*tail as *mut libc::c_char)
-                .c_offset_from(*head as *mut libc::c_char)
-                as libc::c_long as isize,
-        ) as *mut libc::c_void;
-        *head = *start;
-    }
-}
 
 unsafe fn yaml_string_read_handler(
     data: *mut libc::c_void,
@@ -561,95 +455,6 @@ pub unsafe fn yaml_token_delete(token: *mut YamlTokenT) {
         0,
         size_of::<YamlTokenT>() as libc::c_ulong,
     );
-}
-
-/// Checks if the provided UTF-8 encoded string is valid according to the UTF-8 specification.
-///
-/// # Parameters
-///
-/// * `start`: A pointer to the start of the UTF-8 encoded string.
-/// * `length`: The length of the UTF-8 encoded string in bytes.
-///
-/// # Return
-///
-/// Returns `Success::OK` if the string is valid UTF-8, otherwise returns `Success::FAIL`.
-///
-/// # Safety
-///
-/// - `start` must be a valid, non-null pointer to a null-terminated UTF-8 string.
-/// - The UTF-8 encoded string must be properly formatted and not contain any invalid characters.
-/// - The string must be properly null-terminated.
-/// - The string must not contain any invalid characters or sequences.
-///
-pub unsafe fn yaml_check_utf8(
-    start: *const yaml_char_t,
-    length: size_t,
-) -> Success {
-    let end: *const yaml_char_t =
-        start.wrapping_offset(length as isize);
-    let mut pointer: *const yaml_char_t = start;
-
-    while pointer < end {
-        let mut octet: libc::c_uchar;
-        let mut value: libc::c_uint;
-        let mut k: size_t;
-
-        octet = *pointer;
-        let width: libc::c_uint = if octet & 0x80 == 0 {
-            1
-        } else if octet & 0xE0 == 0xC0 {
-            2
-        } else if octet & 0xF0 == 0xE0 {
-            3
-        } else if octet & 0xF8 == 0xF0 {
-            4
-        } else {
-            0
-        } as libc::c_uint;
-
-        value = if octet & 0x80 == 0 {
-            octet & 0x7F
-        } else if octet & 0xE0 == 0xC0 {
-            octet & 0x1F
-        } else if octet & 0xF0 == 0xE0 {
-            octet & 0xF
-        } else if octet & 0xF8 == 0xF0 {
-            octet & 0x7
-        } else {
-            0
-        } as libc::c_uint;
-
-        if width == 0 {
-            return FAIL;
-        }
-
-        if pointer.wrapping_offset(width as isize) > end {
-            return FAIL;
-        }
-
-        k = 1_u64;
-        while k < width as libc::c_ulong {
-            octet = *pointer.wrapping_offset(k as isize);
-            if octet & 0xC0 != 0x80 {
-                return FAIL;
-            }
-            value =
-                (value << 6).force_add((octet & 0x3F) as libc::c_uint);
-            k = k.force_add(1);
-        }
-
-        if !(width == 1
-            || width == 2 && value >= 0x80
-            || width == 3 && value >= 0x800
-            || width == 4 && value >= 0x10000)
-        {
-            return FAIL;
-        }
-
-        pointer = pointer.wrapping_offset(width as isize);
-    }
-
-    OK
 }
 
 /// Create the STREAM-START event.

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,7 @@
 use crate::externs::{
-    free, memcpy, memmove, memset, strdup, strlen,
+    memcpy, memmove, memset, strdup, strlen,
 };
-use crate::memory::{yaml_malloc,yaml_realloc};
+use crate::memory::{yaml_free, yaml_malloc, yaml_realloc};
 use crate::ops::{ForceAdd as _, ForceMul as _};
 use crate::success::{Success, FAIL, OK};
 use crate::yaml::{size_t, yaml_char_t};
@@ -26,25 +26,6 @@ const INPUT_RAW_BUFFER_SIZE: usize = 16384;
 const INPUT_BUFFER_SIZE: usize = INPUT_RAW_BUFFER_SIZE * 3;
 const OUTPUT_BUFFER_SIZE: usize = 16384;
 const OUTPUT_RAW_BUFFER_SIZE: usize = OUTPUT_BUFFER_SIZE * 2 + 2;
-
-/// Free memory allocated by `yaml_malloc` or `yaml_realloc`.
-///
-/// This function is a thin wrapper around the system's `free` function,
-/// used for freeing memory within the LibYML crate.
-///
-/// # Safety
-///
-/// - This function is unsafe because it directly calls the system's `free` function,
-///   which can lead to undefined behaviour if misused.
-/// - The caller must ensure that the provided `ptr` is either a valid pointer returned
-///   by a previous call to `yaml_malloc` or `yaml_realloc`, or a null pointer.
-/// - If `ptr` is a null pointer, no operation is performed.
-///
-pub unsafe fn yaml_free(ptr: *mut libc::c_void) {
-    if !ptr.is_null() {
-        free(ptr);
-    }
-}
 
 /// Duplicate a string using the system's `strdup` function.
 ///

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,26 +1,26 @@
-use crate::externs::{memcpy, memmove, memset, strlen};
-use crate::memory::{
-    yaml_free, yaml_malloc, yaml_realloc, yaml_strdup,
-};
-use crate::ops::{ForceAdd as _, ForceMul as _};
-use crate::success::{Success, FAIL, OK};
-use crate::yaml::{size_t, yaml_char_t};
 use crate::{
-    libc, PointerExt, YamlAliasEvent, YamlAliasToken, YamlAnchorToken,
-    YamlAnyEncoding, YamlBreakT, YamlDocumentEndEvent,
-    YamlDocumentStartEvent, YamlDocumentT, YamlEmitterStateT,
-    YamlEmitterT, YamlEncodingT, YamlEventT, YamlMappingEndEvent,
-    YamlMappingNode, YamlMappingStartEvent, YamlMappingStyleT,
-    YamlMarkT, YamlNodeItemT, YamlNodePairT, YamlNodeT, YamlParserT,
-    YamlReadHandlerT, YamlScalarEvent, YamlScalarNode,
-    YamlScalarStyleT, YamlScalarToken, YamlSequenceEndEvent,
-    YamlSequenceNode, YamlSequenceStartEvent, YamlSequenceStyleT,
-    YamlStreamEndEvent, YamlStreamStartEvent, YamlTagDirectiveT,
-    YamlTagDirectiveToken, YamlTagToken, YamlTokenT,
-    YamlVersionDirectiveT, YamlWriteHandlerT,
+    externs::{memcpy, memmove, memset, strlen},
+    libc,
+    memory::{yaml_free, yaml_malloc, yaml_realloc, yaml_strdup},
+    ops::{ForceAdd as _, ForceMul as _},
+    success::{Success, FAIL, OK},
+    yaml::{size_t, yaml_char_t},
+    PointerExt, YamlAliasEvent, YamlAliasToken, YamlAnchorToken,
+    YamlAnyEncoding, YamlBreakT, YamlEmitterStateT, YamlEmitterT,
+    YamlEncodingT, YamlEventT,
+    YamlEventTypeT::{
+        YamlDocumentStartEvent, YamlScalarEvent, YamlStreamEndEvent,
+    },
+    YamlMappingEndEvent, YamlMappingStartEvent, YamlMappingStyleT,
+    YamlMarkT, YamlParserT, YamlReadHandlerT, YamlScalarStyleT,
+    YamlScalarToken, YamlSequenceEndEvent, YamlSequenceStartEvent,
+    YamlSequenceStyleT, YamlStreamStartEvent, YamlTagDirectiveT,
+    YamlTagDirectiveToken, YamlTagToken, YamlTokenT, YamlWriteHandlerT,
 };
-use core::mem::{size_of, MaybeUninit};
-use core::ptr::{self, addr_of_mut};
+use core::{
+    mem::size_of,
+    ptr::{self, addr_of_mut},
+};
 
 const OUTPUT_BUFFER_SIZE: usize = 16384;
 const OUTPUT_RAW_BUFFER_SIZE: usize = OUTPUT_BUFFER_SIZE * 2 + 2;
@@ -563,17 +563,37 @@ pub unsafe fn yaml_token_delete(token: *mut YamlTokenT) {
     );
 }
 
-unsafe fn yaml_check_utf8(
+/// Checks if the provided UTF-8 encoded string is valid according to the UTF-8 specification.
+///
+/// # Parameters
+///
+/// * `start`: A pointer to the start of the UTF-8 encoded string.
+/// * `length`: The length of the UTF-8 encoded string in bytes.
+///
+/// # Return
+///
+/// Returns `Success::OK` if the string is valid UTF-8, otherwise returns `Success::FAIL`.
+///
+/// # Safety
+///
+/// - `start` must be a valid, non-null pointer to a null-terminated UTF-8 string.
+/// - The UTF-8 encoded string must be properly formatted and not contain any invalid characters.
+/// - The string must be properly null-terminated.
+/// - The string must not contain any invalid characters or sequences.
+///
+pub unsafe fn yaml_check_utf8(
     start: *const yaml_char_t,
     length: size_t,
 ) -> Success {
     let end: *const yaml_char_t =
         start.wrapping_offset(length as isize);
     let mut pointer: *const yaml_char_t = start;
+
     while pointer < end {
         let mut octet: libc::c_uchar;
         let mut value: libc::c_uint;
         let mut k: size_t;
+
         octet = *pointer;
         let width: libc::c_uint = if octet & 0x80 == 0 {
             1
@@ -586,6 +606,7 @@ unsafe fn yaml_check_utf8(
         } else {
             0
         } as libc::c_uint;
+
         value = if octet & 0x80 == 0 {
             octet & 0x7F
         } else if octet & 0xE0 == 0xC0 {
@@ -597,12 +618,15 @@ unsafe fn yaml_check_utf8(
         } else {
             0
         } as libc::c_uint;
+
         if width == 0 {
             return FAIL;
         }
+
         if pointer.wrapping_offset(width as isize) > end {
             return FAIL;
         }
+
         k = 1_u64;
         while k < width as libc::c_ulong {
             octet = *pointer.wrapping_offset(k as isize);
@@ -613,6 +637,7 @@ unsafe fn yaml_check_utf8(
                 (value << 6).force_add((octet & 0x3F) as libc::c_uint);
             k = k.force_add(1);
         }
+
         if !(width == 1
             || width == 2 && value >= 0x80
             || width == 3 && value >= 0x800
@@ -620,8 +645,10 @@ unsafe fn yaml_check_utf8(
         {
             return FAIL;
         }
+
         pointer = pointer.wrapping_offset(width as isize);
     }
+
     OK
 }
 
@@ -684,174 +711,6 @@ pub unsafe fn yaml_stream_end_event_initialize(
     (*event).type_ = YamlStreamEndEvent;
     (*event).start_mark = mark;
     (*event).end_mark = mark;
-    OK
-}
-
-/// Create the DOCUMENT-START event.
-///
-/// The `implicit` argument is considered as a stylistic parameter and may be
-/// ignored by the emitter.
-///
-/// # Safety
-///
-/// - `event` must be a valid, non-null pointer to a `YamlEventT` struct that can be safely written to.
-/// - `version_directive`, if not null, must point to a valid `YamlVersionDirectiveT` struct.
-/// - `tag_directives_start` and `tag_directives_end` must be valid pointers to `YamlTagDirectiveT` structs, or both must be null.
-/// - If `tag_directives_start` and `tag_directives_end` are not null, the range they define must contain valid `YamlTagDirectiveT` structs with non-null `handle` and `prefix` members, and the `handle` and `prefix` strings must be valid UTF-8.
-/// - The `YamlEventT`, `YamlVersionDirectiveT`, and `YamlTagDirectiveT` structs must be properly aligned and have the expected memory layout.
-/// - The caller is responsible for freeing any dynamically allocated memory associated with the event using `yaml_event_delete`.
-///
-pub unsafe fn yaml_document_start_event_initialize(
-    event: *mut YamlEventT,
-    version_directive: *mut YamlVersionDirectiveT,
-    tag_directives_start: *mut YamlTagDirectiveT,
-    tag_directives_end: *mut YamlTagDirectiveT,
-    implicit: bool,
-) -> Success {
-    let current_block: u64;
-    let mark = YamlMarkT {
-        index: 0_u64,
-        line: 0_u64,
-        column: 0_u64,
-    };
-    let mut version_directive_copy: *mut YamlVersionDirectiveT =
-        ptr::null_mut::<YamlVersionDirectiveT>();
-    struct TagDirectivesCopy {
-        start: *mut YamlTagDirectiveT,
-        end: *mut YamlTagDirectiveT,
-        top: *mut YamlTagDirectiveT,
-    }
-    let mut tag_directives_copy = TagDirectivesCopy {
-        start: ptr::null_mut::<YamlTagDirectiveT>(),
-        end: ptr::null_mut::<YamlTagDirectiveT>(),
-        top: ptr::null_mut::<YamlTagDirectiveT>(),
-    };
-    let mut value = YamlTagDirectiveT {
-        handle: ptr::null_mut::<yaml_char_t>(),
-        prefix: ptr::null_mut::<yaml_char_t>(),
-    };
-    __assert!(!event.is_null());
-    __assert!(
-        !tag_directives_start.is_null()
-            && !tag_directives_end.is_null()
-            || tag_directives_start == tag_directives_end
-    );
-    if !version_directive.is_null() {
-        version_directive_copy =
-            yaml_malloc(
-                size_of::<YamlVersionDirectiveT>() as libc::c_ulong
-            ) as *mut YamlVersionDirectiveT;
-        (*version_directive_copy).major = (*version_directive).major;
-        (*version_directive_copy).minor = (*version_directive).minor;
-    }
-    if tag_directives_start != tag_directives_end {
-        let mut tag_directive: *mut YamlTagDirectiveT;
-        STACK_INIT!(tag_directives_copy, YamlTagDirectiveT);
-        tag_directive = tag_directives_start;
-        loop {
-            if tag_directive == tag_directives_end {
-                current_block = 16203760046146113240;
-                break;
-            }
-            __assert!(!((*tag_directive).handle).is_null());
-            __assert!(!((*tag_directive).prefix).is_null());
-            if yaml_check_utf8(
-                (*tag_directive).handle,
-                strlen((*tag_directive).handle as *mut libc::c_char),
-            )
-            .fail
-            {
-                current_block = 14964981520188694172;
-                break;
-            }
-            if yaml_check_utf8(
-                (*tag_directive).prefix,
-                strlen((*tag_directive).prefix as *mut libc::c_char),
-            )
-            .fail
-            {
-                current_block = 14964981520188694172;
-                break;
-            }
-            value.handle = yaml_strdup((*tag_directive).handle);
-            value.prefix = yaml_strdup((*tag_directive).prefix);
-            if value.handle.is_null() || value.prefix.is_null() {
-                current_block = 14964981520188694172;
-                break;
-            }
-            PUSH!(tag_directives_copy, value);
-            value.handle = ptr::null_mut::<yaml_char_t>();
-            value.prefix = ptr::null_mut::<yaml_char_t>();
-            tag_directive = tag_directive.wrapping_offset(1);
-        }
-    } else {
-        current_block = 16203760046146113240;
-    }
-    if current_block != 14964981520188694172 {
-        memset(
-            event as *mut libc::c_void,
-            0,
-            size_of::<YamlEventT>() as libc::c_ulong,
-        );
-        (*event).type_ = YamlDocumentStartEvent;
-        (*event).start_mark = mark;
-        (*event).end_mark = mark;
-        let fresh164 = addr_of_mut!(
-            (*event).data.document_start.version_directive
-        );
-        *fresh164 = version_directive_copy;
-        let fresh165 = addr_of_mut!(
-            (*event).data.document_start.tag_directives.start
-        );
-        *fresh165 = tag_directives_copy.start;
-        let fresh166 = addr_of_mut!(
-            (*event).data.document_start.tag_directives.end
-        );
-        *fresh166 = tag_directives_copy.top;
-        (*event).data.document_start.implicit = implicit;
-        return OK;
-    }
-    yaml_free(version_directive_copy as *mut libc::c_void);
-    while !STACK_EMPTY!(tag_directives_copy) {
-        let value = POP!(tag_directives_copy);
-        yaml_free(value.handle as *mut libc::c_void);
-        yaml_free(value.prefix as *mut libc::c_void);
-    }
-    STACK_DEL!(tag_directives_copy);
-    yaml_free(value.handle as *mut libc::c_void);
-    yaml_free(value.prefix as *mut libc::c_void);
-    FAIL
-}
-
-/// Create the DOCUMENT-END event.
-///
-/// The `implicit` argument is considered as a stylistic parameter and may be
-/// ignored by the emitter.
-///
-/// # Safety
-///
-/// - `event` must be a valid, non-null pointer to a `YamlEventT` struct that can be safely written to.
-/// - The `YamlEventT` struct must be properly aligned and have the expected memory layout.
-///
-pub unsafe fn yaml_document_end_event_initialize(
-    event: *mut YamlEventT,
-    implicit: bool,
-) -> Success {
-    let mark = YamlMarkT {
-        index: 0_u64,
-        line: 0_u64,
-        column: 0_u64,
-    };
-    __assert!(!event.is_null());
-    memset(
-        event as *mut libc::c_void,
-        0,
-        size_of::<YamlEventT>() as libc::c_ulong,
-    );
-    (*event).type_ = YamlDocumentEndEvent;
-    (*event).start_mark = mark;
-    (*event).end_mark = mark;
-    (*event).data.document_end.implicit = implicit;
     OK
 }
 
@@ -1365,604 +1224,4 @@ pub unsafe fn yaml_event_delete(event: *mut YamlEventT) {
         0,
         size_of::<YamlEventT>() as libc::c_ulong,
     );
-}
-
-/// Create a YAML document.
-///
-/// This function initializes a `YamlDocumentT` struct with the provided version directive,
-/// tag directives, and implicit flags. It allocates memory for the document data and
-/// copies the provided directives.
-///
-/// # Safety
-///
-/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct that can be safely written to.
-/// - `version_directive`, if not null, must point to a valid `YamlVersionDirectiveT` struct.
-/// - `tag_directives_start` and `tag_directives_end` must be valid pointers to `YamlTagDirectiveT` structs, or both must be null.
-/// - If `tag_directives_start` and `tag_directives_end` are not null, the range they define must contain valid `YamlTagDirectiveT` structs with non-null `handle` and `prefix` members, and the `handle` and `prefix` strings must be valid UTF-8.
-/// - The `YamlDocumentT`, `YamlVersionDirectiveT`, and `YamlTagDirectiveT` structs must be properly aligned and have the expected memory layout.
-/// - The caller is responsible for freeing the memory allocated for the document using `yaml_document_delete`.
-///
-pub unsafe fn yaml_document_initialize(
-    document: *mut YamlDocumentT,
-    version_directive: *mut YamlVersionDirectiveT,
-    tag_directives_start: *mut YamlTagDirectiveT,
-    tag_directives_end: *mut YamlTagDirectiveT,
-    start_implicit: bool,
-    end_implicit: bool,
-) -> Success {
-    let current_block: u64;
-    struct Nodes {
-        start: *mut YamlNodeT,
-        end: *mut YamlNodeT,
-        top: *mut YamlNodeT,
-    }
-    let mut nodes = Nodes {
-        start: ptr::null_mut::<YamlNodeT>(),
-        end: ptr::null_mut::<YamlNodeT>(),
-        top: ptr::null_mut::<YamlNodeT>(),
-    };
-    let mut version_directive_copy: *mut YamlVersionDirectiveT =
-        ptr::null_mut::<YamlVersionDirectiveT>();
-    struct TagDirectivesCopy {
-        start: *mut YamlTagDirectiveT,
-        end: *mut YamlTagDirectiveT,
-        top: *mut YamlTagDirectiveT,
-    }
-    let mut tag_directives_copy = TagDirectivesCopy {
-        start: ptr::null_mut::<YamlTagDirectiveT>(),
-        end: ptr::null_mut::<YamlTagDirectiveT>(),
-        top: ptr::null_mut::<YamlTagDirectiveT>(),
-    };
-    let mut value = YamlTagDirectiveT {
-        handle: ptr::null_mut::<yaml_char_t>(),
-        prefix: ptr::null_mut::<yaml_char_t>(),
-    };
-    let mark = YamlMarkT {
-        index: 0_u64,
-        line: 0_u64,
-        column: 0_u64,
-    };
-    __assert!(!document.is_null());
-    __assert!(
-        !tag_directives_start.is_null()
-            && !tag_directives_end.is_null()
-            || tag_directives_start == tag_directives_end
-    );
-    STACK_INIT!(nodes, YamlNodeT);
-    if !version_directive.is_null() {
-        version_directive_copy =
-            yaml_malloc(
-                size_of::<YamlVersionDirectiveT>() as libc::c_ulong
-            ) as *mut YamlVersionDirectiveT;
-        (*version_directive_copy).major = (*version_directive).major;
-        (*version_directive_copy).minor = (*version_directive).minor;
-    }
-    if tag_directives_start != tag_directives_end {
-        let mut tag_directive: *mut YamlTagDirectiveT;
-        STACK_INIT!(tag_directives_copy, YamlTagDirectiveT);
-        tag_directive = tag_directives_start;
-        loop {
-            if tag_directive == tag_directives_end {
-                current_block = 14818589718467733107;
-                break;
-            }
-            __assert!(!((*tag_directive).handle).is_null());
-            __assert!(!((*tag_directive).prefix).is_null());
-            if yaml_check_utf8(
-                (*tag_directive).handle,
-                strlen((*tag_directive).handle as *mut libc::c_char),
-            )
-            .fail
-            {
-                current_block = 8142820162064489797;
-                break;
-            }
-            if yaml_check_utf8(
-                (*tag_directive).prefix,
-                strlen((*tag_directive).prefix as *mut libc::c_char),
-            )
-            .fail
-            {
-                current_block = 8142820162064489797;
-                break;
-            }
-            value.handle = yaml_strdup((*tag_directive).handle);
-            value.prefix = yaml_strdup((*tag_directive).prefix);
-            if value.handle.is_null() || value.prefix.is_null() {
-                current_block = 8142820162064489797;
-                break;
-            }
-            PUSH!(tag_directives_copy, value);
-            value.handle = ptr::null_mut::<yaml_char_t>();
-            value.prefix = ptr::null_mut::<yaml_char_t>();
-            tag_directive = tag_directive.wrapping_offset(1);
-        }
-    } else {
-        current_block = 14818589718467733107;
-    }
-    if current_block != 8142820162064489797 {
-        memset(
-            document as *mut libc::c_void,
-            0,
-            size_of::<YamlDocumentT>() as libc::c_ulong,
-        );
-        let fresh176 = addr_of_mut!((*document).nodes.start);
-        *fresh176 = nodes.start;
-        let fresh177 = addr_of_mut!((*document).nodes.end);
-        *fresh177 = nodes.end;
-        let fresh178 = addr_of_mut!((*document).nodes.top);
-        *fresh178 = nodes.start;
-        let fresh179 = addr_of_mut!((*document).version_directive);
-        *fresh179 = version_directive_copy;
-        let fresh180 = addr_of_mut!((*document).tag_directives.start);
-        *fresh180 = tag_directives_copy.start;
-        let fresh181 = addr_of_mut!((*document).tag_directives.end);
-        *fresh181 = tag_directives_copy.top;
-        (*document).start_implicit = start_implicit;
-        (*document).end_implicit = end_implicit;
-        (*document).start_mark = mark;
-        (*document).end_mark = mark;
-        return OK;
-    }
-    STACK_DEL!(nodes);
-    yaml_free(version_directive_copy as *mut libc::c_void);
-    while !STACK_EMPTY!(tag_directives_copy) {
-        let value = POP!(tag_directives_copy);
-        yaml_free(value.handle as *mut libc::c_void);
-        yaml_free(value.prefix as *mut libc::c_void);
-    }
-    STACK_DEL!(tag_directives_copy);
-    yaml_free(value.handle as *mut libc::c_void);
-    yaml_free(value.prefix as *mut libc::c_void);
-    FAIL
-}
-
-/// Delete a YAML document and all its nodes.
-///
-/// This function frees the memory allocated for a `YamlDocumentT` struct and all its associated
-/// nodes, including scalar values, sequences, and mappings.
-///
-/// # Safety
-///
-/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
-/// - The `YamlDocumentT` struct and its associated nodes must have been properly initialized and their memory allocated correctly.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
-///
-pub unsafe fn yaml_document_delete(document: *mut YamlDocumentT) {
-    let mut tag_directive: *mut YamlTagDirectiveT;
-    __assert!(!document.is_null());
-    while !STACK_EMPTY!((*document).nodes) {
-        let mut node = POP!((*document).nodes);
-        yaml_free(node.tag as *mut libc::c_void);
-        match node.type_ {
-            YamlScalarNode => {
-                yaml_free(node.data.scalar.value as *mut libc::c_void);
-            }
-            YamlSequenceNode => {
-                STACK_DEL!(node.data.sequence.items);
-            }
-            YamlMappingNode => {
-                STACK_DEL!(node.data.mapping.pairs);
-            }
-            _ => {
-                __assert!(false);
-            }
-        }
-    }
-    STACK_DEL!((*document).nodes);
-    yaml_free((*document).version_directive as *mut libc::c_void);
-    tag_directive = (*document).tag_directives.start;
-    while tag_directive != (*document).tag_directives.end {
-        yaml_free((*tag_directive).handle as *mut libc::c_void);
-        yaml_free((*tag_directive).prefix as *mut libc::c_void);
-        tag_directive = tag_directive.wrapping_offset(1);
-    }
-    yaml_free((*document).tag_directives.start as *mut libc::c_void);
-    memset(
-        document as *mut libc::c_void,
-        0,
-        size_of::<YamlDocumentT>() as libc::c_ulong,
-    );
-}
-
-/// Get a node of a YAML document.
-///
-/// This function returns a pointer to the node at the specified `index` in the document's node
-/// stack. The pointer returned by this function is valid until any of the functions modifying the
-/// document are called.
-///
-/// Returns the node object or NULL if `index` is out of range.
-///
-/// # Safety
-///
-/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
-/// - `index` must be a valid index within the range of nodes in the `YamlDocumentT` struct.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
-/// - The caller must not modify or free the returned pointer, as it is owned by the `YamlDocumentT` struct.
-///
-pub unsafe fn yaml_document_get_node(
-    document: *mut YamlDocumentT,
-    index: libc::c_int,
-) -> *mut YamlNodeT {
-    __assert!(!document.is_null());
-    if index > 0
-        && (*document).nodes.start.wrapping_offset(index as isize)
-            <= (*document).nodes.top
-    {
-        return (*document)
-            .nodes
-            .start
-            .wrapping_offset(index as isize)
-            .wrapping_offset(-1_isize);
-    }
-    ptr::null_mut::<YamlNodeT>()
-}
-
-/// Get the root of a YAML document node.
-///
-/// This function returns a pointer to the root node of the YAML document. The root object is the
-/// first object added to the document.
-///
-/// The pointer returned by this function is valid until any of the functions modifying the
-/// document are called.
-///
-/// An empty document produced by the parser signifies the end of a YAML stream.
-///
-/// Returns the node object or NULL if the document is empty.
-///
-/// # Safety
-///
-/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
-/// - The caller must not modify or free the returned pointer, as it is owned by the `YamlDocumentT` struct.
-///
-pub unsafe fn yaml_document_get_root_node(
-    document: *mut YamlDocumentT,
-) -> *mut YamlNodeT {
-    __assert!(!document.is_null());
-    if (*document).nodes.top != (*document).nodes.start {
-        return (*document).nodes.start;
-    }
-    ptr::null_mut::<YamlNodeT>()
-}
-
-/// Create a SCALAR node and attach it to the document.
-///
-/// This function creates a new SCALAR node with the provided `tag`, `value`, and `style`, and
-/// adds it to the document's node stack.
-///
-/// The `style` argument may be ignored by the emitter.
-///
-/// Returns the node id or 0 on error.
-///
-/// # Safety
-///
-/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
-/// - `value` must be a valid, non-null pointer to a null-terminated UTF-8 string.
-/// - `tag`, if not null, must be a valid pointer to a null-terminated UTF-8 string.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
-/// - The caller is responsible for freeing the memory allocated for the document using `yaml_document_delete`.
-///
-#[must_use]
-pub unsafe fn yaml_document_add_scalar(
-    document: *mut YamlDocumentT,
-    mut tag: *const yaml_char_t,
-    value: *const yaml_char_t,
-    mut length: libc::c_int,
-    style: YamlScalarStyleT,
-) -> libc::c_int {
-    let mark = YamlMarkT {
-        index: 0_u64,
-        line: 0_u64,
-        column: 0_u64,
-    };
-    let mut tag_copy: *mut yaml_char_t = ptr::null_mut::<yaml_char_t>();
-    let mut value_copy: *mut yaml_char_t =
-        ptr::null_mut::<yaml_char_t>();
-    let mut node = MaybeUninit::<YamlNodeT>::uninit();
-    let node = node.as_mut_ptr();
-    __assert!(!document.is_null());
-    __assert!(!value.is_null());
-    if tag.is_null() {
-        tag = b"tag:yaml.org,2002:str\0" as *const u8
-            as *const libc::c_char as *mut yaml_char_t;
-    }
-    if yaml_check_utf8(tag, strlen(tag as *mut libc::c_char)).ok {
-        tag_copy = yaml_strdup(tag);
-        if !tag_copy.is_null() {
-            if length < 0 {
-                length =
-                    strlen(value as *mut libc::c_char) as libc::c_int;
-            }
-            if yaml_check_utf8(value, length as size_t).ok {
-                value_copy = yaml_malloc(length.force_add(1) as size_t)
-                    as *mut yaml_char_t;
-                memcpy(
-                    value_copy as *mut libc::c_void,
-                    value as *const libc::c_void,
-                    length as libc::c_ulong,
-                );
-                *value_copy.wrapping_offset(length as isize) = b'\0';
-                memset(
-                    node as *mut libc::c_void,
-                    0,
-                    size_of::<YamlNodeT>() as libc::c_ulong,
-                );
-                (*node).type_ = YamlScalarNode;
-                (*node).tag = tag_copy;
-                (*node).start_mark = mark;
-                (*node).end_mark = mark;
-                (*node).data.scalar.value = value_copy;
-                (*node).data.scalar.length = length as size_t;
-                (*node).data.scalar.style = style;
-                PUSH!((*document).nodes, *node);
-                return (*document)
-                    .nodes
-                    .top
-                    .c_offset_from((*document).nodes.start)
-                    as libc::c_int;
-            }
-        }
-    }
-    yaml_free(tag_copy as *mut libc::c_void);
-    yaml_free(value_copy as *mut libc::c_void);
-    0
-}
-
-/// Create a SEQUENCE node and attach it to the document.
-///
-/// This function creates a new SEQUENCE node with the provided `tag` and `style`, and adds it to
-/// the document's node stack.
-///
-/// The `style` argument may be ignored by the emitter.
-///
-/// Returns the node id or 0 on error.
-///
-/// # Safety
-///
-/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
-/// - `tag`, if not null, must be a valid pointer to a null-terminated UTF-8 string.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
-/// - The caller is responsible for freeing the memory allocated for the document using `yaml_document_delete`.
-///
-#[must_use]
-pub unsafe fn yaml_document_add_sequence(
-    document: *mut YamlDocumentT,
-    mut tag: *const yaml_char_t,
-    style: YamlSequenceStyleT,
-) -> libc::c_int {
-    let mark = YamlMarkT {
-        index: 0_u64,
-        line: 0_u64,
-        column: 0_u64,
-    };
-    let mut tag_copy: *mut yaml_char_t = ptr::null_mut::<yaml_char_t>();
-    struct Items {
-        start: *mut YamlNodeItemT,
-        end: *mut YamlNodeItemT,
-        top: *mut YamlNodeItemT,
-    }
-    let mut items = Items {
-        start: ptr::null_mut::<YamlNodeItemT>(),
-        end: ptr::null_mut::<YamlNodeItemT>(),
-        top: ptr::null_mut::<YamlNodeItemT>(),
-    };
-    let mut node = MaybeUninit::<YamlNodeT>::uninit();
-    let node = node.as_mut_ptr();
-    __assert!(!document.is_null());
-    if tag.is_null() {
-        tag = b"tag:yaml.org,2002:seq\0" as *const u8
-            as *const libc::c_char as *mut yaml_char_t;
-    }
-    if yaml_check_utf8(tag, strlen(tag as *mut libc::c_char)).ok {
-        tag_copy = yaml_strdup(tag);
-        if !tag_copy.is_null() {
-            STACK_INIT!(items, YamlNodeItemT);
-            memset(
-                node as *mut libc::c_void,
-                0,
-                size_of::<YamlNodeT>() as libc::c_ulong,
-            );
-            (*node).type_ = YamlSequenceNode;
-            (*node).tag = tag_copy;
-            (*node).start_mark = mark;
-            (*node).end_mark = mark;
-            (*node).data.sequence.items.start = items.start;
-            (*node).data.sequence.items.end = items.end;
-            (*node).data.sequence.items.top = items.start;
-            (*node).data.sequence.style = style;
-            PUSH!((*document).nodes, *node);
-            return (*document)
-                .nodes
-                .top
-                .c_offset_from((*document).nodes.start)
-                as libc::c_int;
-        }
-    }
-    STACK_DEL!(items);
-    yaml_free(tag_copy as *mut libc::c_void);
-    0
-}
-
-/// Create a MAPPING node and attach it to the document.
-///
-/// This function creates a new MAPPING node with the provided `tag` and `style`, and adds it to
-/// the document's node stack.
-///
-/// The `style` argument may be ignored by the emitter.
-///
-/// Returns the node id or 0 on error.
-///
-/// # Safety
-///
-/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
-/// - `tag`, if not null, must be a valid pointer to a null-terminated UTF-8 string.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
-/// - The caller is responsible for freeing the memory allocated for the document using `yaml_document_delete`.
-///
-#[must_use]
-pub unsafe fn yaml_document_add_mapping(
-    document: *mut YamlDocumentT,
-    mut tag: *const yaml_char_t,
-    style: YamlMappingStyleT,
-) -> libc::c_int {
-    let mark = YamlMarkT {
-        index: 0_u64,
-        line: 0_u64,
-        column: 0_u64,
-    };
-    let mut tag_copy: *mut yaml_char_t = ptr::null_mut::<yaml_char_t>();
-    struct Pairs {
-        start: *mut YamlNodePairT,
-        end: *mut YamlNodePairT,
-        top: *mut YamlNodePairT,
-    }
-    let mut pairs = Pairs {
-        start: ptr::null_mut::<YamlNodePairT>(),
-        end: ptr::null_mut::<YamlNodePairT>(),
-        top: ptr::null_mut::<YamlNodePairT>(),
-    };
-    let mut node = MaybeUninit::<YamlNodeT>::uninit();
-    let node = node.as_mut_ptr();
-    __assert!(!document.is_null());
-    if tag.is_null() {
-        tag = b"tag:yaml.org,2002:map\0" as *const u8
-            as *const libc::c_char as *mut yaml_char_t;
-    }
-    if yaml_check_utf8(tag, strlen(tag as *mut libc::c_char)).ok {
-        tag_copy = yaml_strdup(tag);
-        if !tag_copy.is_null() {
-            STACK_INIT!(pairs, YamlNodePairT);
-            memset(
-                node as *mut libc::c_void,
-                0,
-                size_of::<YamlNodeT>() as libc::c_ulong,
-            );
-            (*node).type_ = YamlMappingNode;
-            (*node).tag = tag_copy;
-            (*node).start_mark = mark;
-            (*node).end_mark = mark;
-            (*node).data.mapping.pairs.start = pairs.start;
-            (*node).data.mapping.pairs.end = pairs.end;
-            (*node).data.mapping.pairs.top = pairs.start;
-            (*node).data.mapping.style = style;
-            PUSH!((*document).nodes, *node);
-            return (*document)
-                .nodes
-                .top
-                .c_offset_from((*document).nodes.start)
-                as libc::c_int;
-        }
-    }
-    STACK_DEL!(pairs);
-    yaml_free(tag_copy as *mut libc::c_void);
-    0
-}
-
-/// Add an item to a SEQUENCE node.
-///
-/// This function adds a node with the given `item` id to the sequence node with the given
-/// `sequence` id in the document.
-///
-/// # Safety
-///
-/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
-/// - `sequence` must be a valid index within the range of nodes in the `YamlDocumentT` struct, and the node at that index must be a `YamlSequenceNode`.
-/// - `item` must be a valid index within the range of nodes in the `YamlDocumentT` struct.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
-///
-pub unsafe fn yaml_document_append_sequence_item(
-    document: *mut YamlDocumentT,
-    sequence: libc::c_int,
-    item: libc::c_int,
-) -> Success {
-    __assert!(!document.is_null());
-    __assert!(
-        sequence > 0
-            && ((*document).nodes.start)
-                .wrapping_offset(sequence as isize)
-                <= (*document).nodes.top
-    );
-    __assert!(
-        (*((*document).nodes.start)
-            .wrapping_offset((sequence - 1) as isize))
-        .type_
-            == YamlSequenceNode
-    );
-    __assert!(
-        item > 0
-            && ((*document).nodes.start).wrapping_offset(item as isize)
-                <= (*document).nodes.top
-    );
-    PUSH!(
-        (*((*document).nodes.start)
-            .wrapping_offset((sequence - 1) as isize))
-        .data
-        .sequence
-        .items,
-        item
-    );
-    OK
-}
-
-/// Add a pair of a key and a value to a MAPPING node.
-///
-/// This function adds a key-value pair to the mapping node with the given `mapping` id in the
-/// document. The `key` and `value` arguments are the ids of the nodes to be used as the key and
-/// value, respectively.
-///
-/// # Safety
-///
-/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
-/// - `mapping` must be a valid index within the range of nodes in the `YamlDocumentT` struct, and the node at that index must be a `YamlMappingNode`.
-/// - `key` and `value` must be valid indices within the range of nodes in the `YamlDocumentT` struct.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
-/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
-///
-pub unsafe fn yaml_document_append_mapping_pair(
-    document: *mut YamlDocumentT,
-    mapping: libc::c_int,
-    key: libc::c_int,
-    value: libc::c_int,
-) -> Success {
-    __assert!(!document.is_null());
-    __assert!(
-        mapping > 0
-            && ((*document).nodes.start)
-                .wrapping_offset(mapping as isize)
-                <= (*document).nodes.top
-    );
-    __assert!(
-        (*((*document).nodes.start)
-            .wrapping_offset((mapping - 1) as isize))
-        .type_
-            == YamlMappingNode
-    );
-    __assert!(
-        key > 0
-            && ((*document).nodes.start).wrapping_offset(key as isize)
-                <= (*document).nodes.top
-    );
-    __assert!(
-        value > 0
-            && ((*document).nodes.start)
-                .wrapping_offset(value as isize)
-                <= (*document).nodes.top
-    );
-    let pair = YamlNodePairT { key, value };
-    PUSH!(
-        (*((*document).nodes.start)
-            .wrapping_offset((mapping - 1) as isize))
-        .data
-        .mapping
-        .pairs,
-        pair
-    );
-    OK
 }

--- a/src/bin/run-emitter-test-suite.rs
+++ b/src/bin/run-emitter-test-suite.rs
@@ -21,18 +21,12 @@ mod cstr;
 use self::cstr::CStr;
 pub(crate) use core::primitive::u8 as yaml_char_t;
 use libyml::api::ScalarEventData;
-use std::env;
-use std::error::Error;
-use std::ffi::c_void;
-use std::fs::File;
-use std::io::{self, Read, Write};
-use std::mem::MaybeUninit;
-use std::process::{self, ExitCode};
-use std::ptr::{self, addr_of_mut};
-// use std::slice;
+use libyml::document::{
+    yaml_document_end_event_initialize,
+    yaml_document_start_event_initialize,
+};
 use libyml::{
-    yaml_alias_event_initialize, yaml_document_end_event_initialize,
-    yaml_document_start_event_initialize, yaml_emitter_delete,
+    yaml_alias_event_initialize, yaml_emitter_delete,
     yaml_emitter_emit, yaml_emitter_initialize,
     yaml_emitter_set_canonical, yaml_emitter_set_output,
     yaml_emitter_set_unicode, yaml_mapping_end_event_initialize,
@@ -48,6 +42,14 @@ use libyml::{
     YamlSingleQuotedScalarStyle, YamlTagDirectiveT, YamlUtf8Encoding,
     YamlVersionDirectiveT, YamlWriterError,
 };
+use std::env;
+use std::error::Error;
+use std::ffi::c_void;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::mem::MaybeUninit;
+use std::process::{self, ExitCode};
+use std::ptr::{self, addr_of_mut};
 
 pub(crate) unsafe fn unsafe_main(
     stdin: &mut dyn Read,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,0 +1,90 @@
+// decode.rs
+// Manages the decoding of YAML data structures in Rust, handling the lifecycle of YAML parsers.
+
+use crate::{
+    libc,
+    memory::{yaml_free, yaml_malloc},
+    success::{Success, OK},
+    yaml::{size_t, yaml_char_t},
+    yaml_token_delete, YamlMarkT, YamlParserStateT, YamlParserT,
+    YamlSimpleKeyT, YamlTagDirectiveT, YamlTokenT,
+};
+
+use crate::externs::memset;
+use core::{
+    mem::size_of,
+    ptr::{self, addr_of_mut},
+};
+
+const INPUT_RAW_BUFFER_SIZE: usize = 16384;
+const INPUT_BUFFER_SIZE: usize = INPUT_RAW_BUFFER_SIZE * 3;
+// const OUTPUT_BUFFER_SIZE: usize = 16384;
+// const OUTPUT_RAW_BUFFER_SIZE: usize = OUTPUT_BUFFER_SIZE * 2 + 2;
+
+/// Initialize a parser.
+///
+/// This function creates a new parser object. An application is responsible
+/// for destroying the object using the yaml_parser_delete() function.
+///
+/// # Safety
+///
+/// - `parser` must be a valid, non-null pointer to an uninitialized `YamlParserT` struct.
+/// - The `YamlParserT` struct must be properly aligned and have the expected memory layout.
+/// - The caller is responsible for properly destroying the parser object using `yaml_parser_delete`.
+///
+pub unsafe fn yaml_parser_initialize(
+    parser: *mut YamlParserT,
+) -> Success {
+    __assert!(!parser.is_null());
+    memset(
+        parser as *mut libc::c_void,
+        0,
+        size_of::<YamlParserT>() as libc::c_ulong,
+    );
+    BUFFER_INIT!((*parser).raw_buffer, INPUT_RAW_BUFFER_SIZE);
+    BUFFER_INIT!((*parser).buffer, INPUT_BUFFER_SIZE);
+    QUEUE_INIT!((*parser).tokens, YamlTokenT);
+    STACK_INIT!((*parser).indents, libc::c_int);
+    STACK_INIT!((*parser).simple_keys, YamlSimpleKeyT);
+    STACK_INIT!((*parser).states, YamlParserStateT);
+    STACK_INIT!((*parser).marks, YamlMarkT);
+    STACK_INIT!((*parser).tag_directives, YamlTagDirectiveT);
+    OK
+}
+
+/// Destroy a parser.
+///
+/// This function frees all memory associated with a parser object, including
+/// any dynamically allocated buffers, tokens, and other data structures.
+///
+/// # Safety
+///
+/// - `parser` must be a valid, non-null pointer to a properly initialized `YamlParserT` struct.
+/// - The `YamlParserT` struct and its associated data structures must have been properly initialized and their memory allocated correctly.
+/// - The `YamlParserT` struct and its associated data structures must be properly aligned and have the expected memory layout.
+/// - After calling this function, the `parser` pointer should be considered invalid and should not be used again.
+///
+pub unsafe fn yaml_parser_delete(parser: *mut YamlParserT) {
+    __assert!(!parser.is_null());
+    BUFFER_DEL!((*parser).raw_buffer);
+    BUFFER_DEL!((*parser).buffer);
+    while !QUEUE_EMPTY!((*parser).tokens) {
+        yaml_token_delete(addr_of_mut!(DEQUEUE!((*parser).tokens)));
+    }
+    QUEUE_DEL!((*parser).tokens);
+    STACK_DEL!((*parser).indents);
+    STACK_DEL!((*parser).simple_keys);
+    STACK_DEL!((*parser).states);
+    STACK_DEL!((*parser).marks);
+    while !STACK_EMPTY!((*parser).tag_directives) {
+        let tag_directive = POP!((*parser).tag_directives);
+        yaml_free(tag_directive.handle as *mut libc::c_void);
+        yaml_free(tag_directive.prefix as *mut libc::c_void);
+    }
+    STACK_DEL!((*parser).tag_directives);
+    memset(
+        parser as *mut libc::c_void,
+        0,
+        size_of::<YamlParserT>() as libc::c_ulong,
+    );
+}

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,0 +1,785 @@
+use crate::api::yaml_check_utf8;
+use crate::api::yaml_stack_extend;
+use crate::externs::{memcpy, memset, strlen};
+use crate::memory::{yaml_free, yaml_malloc, yaml_strdup};
+use crate::ops::ForceAdd;
+use crate::success::{Success, FAIL, OK};
+use crate::yaml::{size_t, yaml_char_t};
+use crate::YamlEventT;
+use crate::YamlEventTypeT::YamlDocumentEndEvent;
+use crate::YamlEventTypeT::YamlDocumentStartEvent;
+use crate::{
+    libc, PointerExt, YamlDocumentT, YamlMappingNode,
+    YamlMappingStyleT, YamlMarkT, YamlNodeItemT, YamlNodePairT,
+    YamlNodeT, YamlScalarNode, YamlScalarStyleT, YamlSequenceNode,
+    YamlSequenceStyleT, YamlTagDirectiveT, YamlVersionDirectiveT,
+};
+use core::mem::{size_of, MaybeUninit};
+use core::ptr::{self, addr_of_mut};
+/// Create a YAML document.
+///
+/// This function initializes a `YamlDocumentT` struct with the provided version directive,
+/// tag directives, and implicit flags. It allocates memory for the document data and
+/// copies the provided directives.
+///
+/// # Safety
+///
+/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct that can be safely written to.
+/// - `version_directive`, if not null, must point to a valid `YamlVersionDirectiveT` struct.
+/// - `tag_directives_start` and `tag_directives_end` must be valid pointers to `YamlTagDirectiveT` structs, or both must be null.
+/// - If `tag_directives_start` and `tag_directives_end` are not null, the range they define must contain valid `YamlTagDirectiveT` structs with non-null `handle` and `prefix` members, and the `handle` and `prefix` strings must be valid UTF-8.
+/// - The `YamlDocumentT`, `YamlVersionDirectiveT`, and `YamlTagDirectiveT` structs must be properly aligned and have the expected memory layout.
+/// - The caller is responsible for freeing the memory allocated for the document using `yaml_document_delete`.
+///
+pub unsafe fn yaml_document_initialize(
+    document: *mut YamlDocumentT,
+    version_directive: *mut YamlVersionDirectiveT,
+    tag_directives_start: *mut YamlTagDirectiveT,
+    tag_directives_end: *mut YamlTagDirectiveT,
+    start_implicit: bool,
+    end_implicit: bool,
+) -> Success {
+    let current_block: u64;
+    struct Nodes {
+        start: *mut YamlNodeT,
+        end: *mut YamlNodeT,
+        top: *mut YamlNodeT,
+    }
+    let mut nodes = Nodes {
+        start: ptr::null_mut::<YamlNodeT>(),
+        end: ptr::null_mut::<YamlNodeT>(),
+        top: ptr::null_mut::<YamlNodeT>(),
+    };
+    let mut version_directive_copy: *mut YamlVersionDirectiveT =
+        ptr::null_mut::<YamlVersionDirectiveT>();
+    struct TagDirectivesCopy {
+        start: *mut YamlTagDirectiveT,
+        end: *mut YamlTagDirectiveT,
+        top: *mut YamlTagDirectiveT,
+    }
+    let mut tag_directives_copy = TagDirectivesCopy {
+        start: ptr::null_mut::<YamlTagDirectiveT>(),
+        end: ptr::null_mut::<YamlTagDirectiveT>(),
+        top: ptr::null_mut::<YamlTagDirectiveT>(),
+    };
+    let mut value = YamlTagDirectiveT {
+        handle: ptr::null_mut::<yaml_char_t>(),
+        prefix: ptr::null_mut::<yaml_char_t>(),
+    };
+    let mark = YamlMarkT {
+        index: 0_u64,
+        line: 0_u64,
+        column: 0_u64,
+    };
+    __assert!(!document.is_null());
+    __assert!(
+        !tag_directives_start.is_null()
+            && !tag_directives_end.is_null()
+            || tag_directives_start == tag_directives_end
+    );
+    STACK_INIT!(nodes, YamlNodeT);
+    if !version_directive.is_null() {
+        version_directive_copy =
+            yaml_malloc(
+                size_of::<YamlVersionDirectiveT>() as libc::c_ulong
+            ) as *mut YamlVersionDirectiveT;
+        (*version_directive_copy).major = (*version_directive).major;
+        (*version_directive_copy).minor = (*version_directive).minor;
+    }
+    if tag_directives_start != tag_directives_end {
+        let mut tag_directive: *mut YamlTagDirectiveT;
+        STACK_INIT!(tag_directives_copy, YamlTagDirectiveT);
+        tag_directive = tag_directives_start;
+        loop {
+            if tag_directive == tag_directives_end {
+                current_block = 14818589718467733107;
+                break;
+            }
+            __assert!(!((*tag_directive).handle).is_null());
+            __assert!(!((*tag_directive).prefix).is_null());
+            if yaml_check_utf8(
+                (*tag_directive).handle,
+                strlen((*tag_directive).handle as *mut libc::c_char),
+            )
+            .fail
+            {
+                current_block = 8142820162064489797;
+                break;
+            }
+            if yaml_check_utf8(
+                (*tag_directive).prefix,
+                strlen((*tag_directive).prefix as *mut libc::c_char),
+            )
+            .fail
+            {
+                current_block = 8142820162064489797;
+                break;
+            }
+            value.handle = yaml_strdup((*tag_directive).handle);
+            value.prefix = yaml_strdup((*tag_directive).prefix);
+            if value.handle.is_null() || value.prefix.is_null() {
+                current_block = 8142820162064489797;
+                break;
+            }
+            PUSH!(tag_directives_copy, value);
+            value.handle = ptr::null_mut::<yaml_char_t>();
+            value.prefix = ptr::null_mut::<yaml_char_t>();
+            tag_directive = tag_directive.wrapping_offset(1);
+        }
+    } else {
+        current_block = 14818589718467733107;
+    }
+    if current_block != 8142820162064489797 {
+        memset(
+            document as *mut libc::c_void,
+            0,
+            size_of::<YamlDocumentT>() as libc::c_ulong,
+        );
+        let fresh176 = addr_of_mut!((*document).nodes.start);
+        *fresh176 = nodes.start;
+        let fresh177 = addr_of_mut!((*document).nodes.end);
+        *fresh177 = nodes.end;
+        let fresh178 = addr_of_mut!((*document).nodes.top);
+        *fresh178 = nodes.start;
+        let fresh179 = addr_of_mut!((*document).version_directive);
+        *fresh179 = version_directive_copy;
+        let fresh180 = addr_of_mut!((*document).tag_directives.start);
+        *fresh180 = tag_directives_copy.start;
+        let fresh181 = addr_of_mut!((*document).tag_directives.end);
+        *fresh181 = tag_directives_copy.top;
+        (*document).start_implicit = start_implicit;
+        (*document).end_implicit = end_implicit;
+        (*document).start_mark = mark;
+        (*document).end_mark = mark;
+        return OK;
+    }
+    STACK_DEL!(nodes);
+    yaml_free(version_directive_copy as *mut libc::c_void);
+    while !STACK_EMPTY!(tag_directives_copy) {
+        let value = POP!(tag_directives_copy);
+        yaml_free(value.handle as *mut libc::c_void);
+        yaml_free(value.prefix as *mut libc::c_void);
+    }
+    STACK_DEL!(tag_directives_copy);
+    yaml_free(value.handle as *mut libc::c_void);
+    yaml_free(value.prefix as *mut libc::c_void);
+    FAIL
+}
+
+/// Delete a YAML document and all its nodes.
+///
+/// This function frees the memory allocated for a `YamlDocumentT` struct and all its associated
+/// nodes, including scalar values, sequences, and mappings.
+///
+/// # Safety
+///
+/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
+/// - The `YamlDocumentT` struct and its associated nodes must have been properly initialized and their memory allocated correctly.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
+///
+pub unsafe fn yaml_document_delete(document: *mut YamlDocumentT) {
+    let mut tag_directive: *mut YamlTagDirectiveT;
+    __assert!(!document.is_null());
+    while !STACK_EMPTY!((*document).nodes) {
+        let mut node = POP!((*document).nodes);
+        yaml_free(node.tag as *mut libc::c_void);
+        match node.type_ {
+            YamlScalarNode => {
+                yaml_free(node.data.scalar.value as *mut libc::c_void);
+            }
+            YamlSequenceNode => {
+                STACK_DEL!(node.data.sequence.items);
+            }
+            YamlMappingNode => {
+                STACK_DEL!(node.data.mapping.pairs);
+            }
+            _ => {
+                __assert!(false);
+            }
+        }
+    }
+    STACK_DEL!((*document).nodes);
+    yaml_free((*document).version_directive as *mut libc::c_void);
+    tag_directive = (*document).tag_directives.start;
+    while tag_directive != (*document).tag_directives.end {
+        yaml_free((*tag_directive).handle as *mut libc::c_void);
+        yaml_free((*tag_directive).prefix as *mut libc::c_void);
+        tag_directive = tag_directive.wrapping_offset(1);
+    }
+    yaml_free((*document).tag_directives.start as *mut libc::c_void);
+    memset(
+        document as *mut libc::c_void,
+        0,
+        size_of::<YamlDocumentT>() as libc::c_ulong,
+    );
+}
+
+/// Get a node of a YAML document.
+///
+/// This function returns a pointer to the node at the specified `index` in the document's node
+/// stack. The pointer returned by this function is valid until any of the functions modifying the
+/// document are called.
+///
+/// Returns the node object or NULL if `index` is out of range.
+///
+/// # Safety
+///
+/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
+/// - `index` must be a valid index within the range of nodes in the `YamlDocumentT` struct.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
+/// - The caller must not modify or free the returned pointer, as it is owned by the `YamlDocumentT` struct.
+///
+pub unsafe fn yaml_document_get_node(
+    document: *mut YamlDocumentT,
+    index: libc::c_int,
+) -> *mut YamlNodeT {
+    __assert!(!document.is_null());
+    if index > 0
+        && (*document).nodes.start.wrapping_offset(index as isize)
+            <= (*document).nodes.top
+    {
+        return (*document)
+            .nodes
+            .start
+            .wrapping_offset(index as isize)
+            .wrapping_offset(-1_isize);
+    }
+    ptr::null_mut::<YamlNodeT>()
+}
+
+/// Get the root of a YAML document node.
+///
+/// This function returns a pointer to the root node of the YAML document. The root object is the
+/// first object added to the document.
+///
+/// The pointer returned by this function is valid until any of the functions modifying the
+/// document are called.
+///
+/// An empty document produced by the parser signifies the end of a YAML stream.
+///
+/// Returns the node object or NULL if the document is empty.
+///
+/// # Safety
+///
+/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
+/// - The caller must not modify or free the returned pointer, as it is owned by the `YamlDocumentT` struct.
+///
+pub unsafe fn yaml_document_get_root_node(
+    document: *mut YamlDocumentT,
+) -> *mut YamlNodeT {
+    __assert!(!document.is_null());
+    if (*document).nodes.top != (*document).nodes.start {
+        return (*document).nodes.start;
+    }
+    ptr::null_mut::<YamlNodeT>()
+}
+
+/// Create a SCALAR node and attach it to the document.
+///
+/// This function creates a new SCALAR node with the provided `tag`, `value`, and `style`, and
+/// adds it to the document's node stack.
+///
+/// The `style` argument may be ignored by the emitter.
+///
+/// Returns the node id or 0 on error.
+///
+/// # Safety
+///
+/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
+/// - `value` must be a valid, non-null pointer to a null-terminated UTF-8 string.
+/// - `tag`, if not null, must be a valid pointer to a null-terminated UTF-8 string.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
+/// - The caller is responsible for freeing the memory allocated for the document using `yaml_document_delete`.
+///
+#[must_use]
+pub unsafe fn yaml_document_add_scalar(
+    document: *mut YamlDocumentT,
+    mut tag: *const yaml_char_t,
+    value: *const yaml_char_t,
+    mut length: libc::c_int,
+    style: YamlScalarStyleT,
+) -> libc::c_int {
+    let mark = YamlMarkT {
+        index: 0_u64,
+        line: 0_u64,
+        column: 0_u64,
+    };
+    let mut tag_copy: *mut yaml_char_t = ptr::null_mut::<yaml_char_t>();
+    let mut value_copy: *mut yaml_char_t =
+        ptr::null_mut::<yaml_char_t>();
+    let mut node = MaybeUninit::<YamlNodeT>::uninit();
+    let node = node.as_mut_ptr();
+    __assert!(!document.is_null());
+    __assert!(!value.is_null());
+    if tag.is_null() {
+        tag = b"tag:yaml.org,2002:str\0" as *const u8
+            as *const libc::c_char as *mut yaml_char_t;
+    }
+    if yaml_check_utf8(tag, strlen(tag as *mut libc::c_char)).ok {
+        tag_copy = yaml_strdup(tag);
+        if !tag_copy.is_null() {
+            if length < 0 {
+                length =
+                    strlen(value as *mut libc::c_char) as libc::c_int;
+            }
+            if yaml_check_utf8(value, length as size_t).ok {
+                value_copy = yaml_malloc(length.force_add(1) as size_t)
+                    as *mut yaml_char_t;
+                memcpy(
+                    value_copy as *mut libc::c_void,
+                    value as *const libc::c_void,
+                    length as libc::c_ulong,
+                );
+                *value_copy.wrapping_offset(length as isize) = b'\0';
+                memset(
+                    node as *mut libc::c_void,
+                    0,
+                    size_of::<YamlNodeT>() as libc::c_ulong,
+                );
+                (*node).type_ = YamlScalarNode;
+                (*node).tag = tag_copy;
+                (*node).start_mark = mark;
+                (*node).end_mark = mark;
+                (*node).data.scalar.value = value_copy;
+                (*node).data.scalar.length = length as size_t;
+                (*node).data.scalar.style = style;
+                PUSH!((*document).nodes, *node);
+                return (*document)
+                    .nodes
+                    .top
+                    .c_offset_from((*document).nodes.start)
+                    as libc::c_int;
+            }
+        }
+    }
+    yaml_free(tag_copy as *mut libc::c_void);
+    yaml_free(value_copy as *mut libc::c_void);
+    0
+}
+
+/// Create a SEQUENCE node and attach it to the document.
+///
+/// This function creates a new SEQUENCE node with the provided `tag` and `style`, and adds it to
+/// the document's node stack.
+///
+/// The `style` argument may be ignored by the emitter.
+///
+/// Returns the node id or 0 on error.
+///
+/// # Safety
+///
+/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
+/// - `tag`, if not null, must be a valid pointer to a null-terminated UTF-8 string.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
+/// - The caller is responsible for freeing the memory allocated for the document using `yaml_document_delete`.
+///
+#[must_use]
+pub unsafe fn yaml_document_add_sequence(
+    document: *mut YamlDocumentT,
+    mut tag: *const yaml_char_t,
+    style: YamlSequenceStyleT,
+) -> libc::c_int {
+    let mark = YamlMarkT {
+        index: 0_u64,
+        line: 0_u64,
+        column: 0_u64,
+    };
+    let mut tag_copy: *mut yaml_char_t = ptr::null_mut::<yaml_char_t>();
+    struct Items {
+        start: *mut YamlNodeItemT,
+        end: *mut YamlNodeItemT,
+        top: *mut YamlNodeItemT,
+    }
+    let mut items = Items {
+        start: ptr::null_mut::<YamlNodeItemT>(),
+        end: ptr::null_mut::<YamlNodeItemT>(),
+        top: ptr::null_mut::<YamlNodeItemT>(),
+    };
+    let mut node = MaybeUninit::<YamlNodeT>::uninit();
+    let node = node.as_mut_ptr();
+    __assert!(!document.is_null());
+    if tag.is_null() {
+        tag = b"tag:yaml.org,2002:seq\0" as *const u8
+            as *const libc::c_char as *mut yaml_char_t;
+    }
+    if yaml_check_utf8(tag, strlen(tag as *mut libc::c_char)).ok {
+        tag_copy = yaml_strdup(tag);
+        if !tag_copy.is_null() {
+            STACK_INIT!(items, YamlNodeItemT);
+            memset(
+                node as *mut libc::c_void,
+                0,
+                size_of::<YamlNodeT>() as libc::c_ulong,
+            );
+            (*node).type_ = YamlSequenceNode;
+            (*node).tag = tag_copy;
+            (*node).start_mark = mark;
+            (*node).end_mark = mark;
+            (*node).data.sequence.items.start = items.start;
+            (*node).data.sequence.items.end = items.end;
+            (*node).data.sequence.items.top = items.start;
+            (*node).data.sequence.style = style;
+            PUSH!((*document).nodes, *node);
+            return (*document)
+                .nodes
+                .top
+                .c_offset_from((*document).nodes.start)
+                as libc::c_int;
+        }
+    }
+    STACK_DEL!(items);
+    yaml_free(tag_copy as *mut libc::c_void);
+    0
+}
+
+/// Create a MAPPING node and attach it to the document.
+///
+/// This function creates a new MAPPING node with the provided `tag` and `style`, and adds it to
+/// the document's node stack.
+///
+/// The `style` argument may be ignored by the emitter.
+///
+/// Returns the node id or 0 on error.
+///
+/// # Safety
+///
+/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
+/// - `tag`, if not null, must be a valid pointer to a null-terminated UTF-8 string.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
+/// - The caller is responsible for freeing the memory allocated for the document using `yaml_document_delete`.
+///
+#[must_use]
+pub unsafe fn yaml_document_add_mapping(
+    document: *mut YamlDocumentT,
+    mut tag: *const yaml_char_t,
+    style: YamlMappingStyleT,
+) -> libc::c_int {
+    let mark = YamlMarkT {
+        index: 0_u64,
+        line: 0_u64,
+        column: 0_u64,
+    };
+    let mut tag_copy: *mut yaml_char_t = ptr::null_mut::<yaml_char_t>();
+    struct Pairs {
+        start: *mut YamlNodePairT,
+        end: *mut YamlNodePairT,
+        top: *mut YamlNodePairT,
+    }
+    let mut pairs = Pairs {
+        start: ptr::null_mut::<YamlNodePairT>(),
+        end: ptr::null_mut::<YamlNodePairT>(),
+        top: ptr::null_mut::<YamlNodePairT>(),
+    };
+    let mut node = MaybeUninit::<YamlNodeT>::uninit();
+    let node = node.as_mut_ptr();
+    __assert!(!document.is_null());
+    if tag.is_null() {
+        tag = b"tag:yaml.org,2002:map\0" as *const u8
+            as *const libc::c_char as *mut yaml_char_t;
+    }
+    if yaml_check_utf8(tag, strlen(tag as *mut libc::c_char)).ok {
+        tag_copy = yaml_strdup(tag);
+        if !tag_copy.is_null() {
+            STACK_INIT!(pairs, YamlNodePairT);
+            memset(
+                node as *mut libc::c_void,
+                0,
+                size_of::<YamlNodeT>() as libc::c_ulong,
+            );
+            (*node).type_ = YamlMappingNode;
+            (*node).tag = tag_copy;
+            (*node).start_mark = mark;
+            (*node).end_mark = mark;
+            (*node).data.mapping.pairs.start = pairs.start;
+            (*node).data.mapping.pairs.end = pairs.end;
+            (*node).data.mapping.pairs.top = pairs.start;
+            (*node).data.mapping.style = style;
+            PUSH!((*document).nodes, *node);
+            return (*document)
+                .nodes
+                .top
+                .c_offset_from((*document).nodes.start)
+                as libc::c_int;
+        }
+    }
+    STACK_DEL!(pairs);
+    yaml_free(tag_copy as *mut libc::c_void);
+    0
+}
+
+/// Add an item to a SEQUENCE node.
+///
+/// This function adds a node with the given `item` id to the sequence node with the given
+/// `sequence` id in the document.
+///
+/// # Safety
+///
+/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
+/// - `sequence` must be a valid index within the range of nodes in the `YamlDocumentT` struct, and the node at that index must be a `YamlSequenceNode`.
+/// - `item` must be a valid index within the range of nodes in the `YamlDocumentT` struct.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
+///
+pub unsafe fn yaml_document_append_sequence_item(
+    document: *mut YamlDocumentT,
+    sequence: libc::c_int,
+    item: libc::c_int,
+) -> Success {
+    __assert!(!document.is_null());
+    __assert!(
+        sequence > 0
+            && ((*document).nodes.start)
+                .wrapping_offset(sequence as isize)
+                <= (*document).nodes.top
+    );
+    __assert!(
+        (*((*document).nodes.start)
+            .wrapping_offset((sequence - 1) as isize))
+        .type_
+            == YamlSequenceNode
+    );
+    __assert!(
+        item > 0
+            && ((*document).nodes.start).wrapping_offset(item as isize)
+                <= (*document).nodes.top
+    );
+    PUSH!(
+        (*((*document).nodes.start)
+            .wrapping_offset((sequence - 1) as isize))
+        .data
+        .sequence
+        .items,
+        item
+    );
+    OK
+}
+
+/// Add a pair of a key and a value to a MAPPING node.
+///
+/// This function adds a key-value pair to the mapping node with the given `mapping` id in the
+/// document. The `key` and `value` arguments are the ids of the nodes to be used as the key and
+/// value, respectively.
+///
+/// # Safety
+///
+/// - `document` must be a valid, non-null pointer to a `YamlDocumentT` struct.
+/// - `mapping` must be a valid index within the range of nodes in the `YamlDocumentT` struct, and the node at that index must be a `YamlMappingNode`.
+/// - `key` and `value` must be valid indices within the range of nodes in the `YamlDocumentT` struct.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly initialized and their memory allocated correctly.
+/// - The `YamlDocumentT` struct and its associated nodes must be properly aligned and have the expected memory layout.
+///
+pub unsafe fn yaml_document_append_mapping_pair(
+    document: *mut YamlDocumentT,
+    mapping: libc::c_int,
+    key: libc::c_int,
+    value: libc::c_int,
+) -> Success {
+    __assert!(!document.is_null());
+    __assert!(
+        mapping > 0
+            && ((*document).nodes.start)
+                .wrapping_offset(mapping as isize)
+                <= (*document).nodes.top
+    );
+    __assert!(
+        (*((*document).nodes.start)
+            .wrapping_offset((mapping - 1) as isize))
+        .type_
+            == YamlMappingNode
+    );
+    __assert!(
+        key > 0
+            && ((*document).nodes.start).wrapping_offset(key as isize)
+                <= (*document).nodes.top
+    );
+    __assert!(
+        value > 0
+            && ((*document).nodes.start)
+                .wrapping_offset(value as isize)
+                <= (*document).nodes.top
+    );
+    let pair = YamlNodePairT { key, value };
+    PUSH!(
+        (*((*document).nodes.start)
+            .wrapping_offset((mapping - 1) as isize))
+        .data
+        .mapping
+        .pairs,
+        pair
+    );
+    OK
+}
+
+/// Create the DOCUMENT-END event.
+///
+/// The `implicit` argument is considered as a stylistic parameter and may be
+/// ignored by the emitter.
+///
+/// # Safety
+///
+/// - `event` must be a valid, non-null pointer to a `YamlEventT` struct that can be safely written to.
+/// - The `YamlEventT` struct must be properly aligned and have the expected memory layout.
+///
+pub unsafe fn yaml_document_end_event_initialize(
+    event: *mut YamlEventT,
+    implicit: bool,
+) -> Success {
+    let mark = YamlMarkT {
+        index: 0_u64,
+        line: 0_u64,
+        column: 0_u64,
+    };
+    __assert!(!event.is_null());
+    memset(
+        event as *mut libc::c_void,
+        0,
+        size_of::<YamlEventT>() as libc::c_ulong,
+    );
+    (*event).type_ = YamlDocumentEndEvent;
+    (*event).start_mark = mark;
+    (*event).end_mark = mark;
+    (*event).data.document_end.implicit = implicit;
+    OK
+}
+
+/// Create the DOCUMENT-START event.
+///
+/// The `implicit` argument is considered as a stylistic parameter and may be
+/// ignored by the emitter.
+///
+/// # Safety
+///
+/// - `event` must be a valid, non-null pointer to a `YamlEventT` struct that can be safely written to.
+/// - `version_directive`, if not null, must point to a valid `YamlVersionDirectiveT` struct.
+/// - `tag_directives_start` and `tag_directives_end` must be valid pointers to `YamlTagDirectiveT` structs, or both must be null.
+/// - If `tag_directives_start` and `tag_directives_end` are not null, the range they define must contain valid `YamlTagDirectiveT` structs with non-null `handle` and `prefix` members, and the `handle` and `prefix` strings must be valid UTF-8.
+/// - The `YamlEventT`, `YamlVersionDirectiveT`, and `YamlTagDirectiveT` structs must be properly aligned and have the expected memory layout.
+/// - The caller is responsible for freeing any dynamically allocated memory associated with the event using `yaml_event_delete`.
+///
+pub unsafe fn yaml_document_start_event_initialize(
+    event: *mut YamlEventT,
+    version_directive: *mut YamlVersionDirectiveT,
+    tag_directives_start: *mut YamlTagDirectiveT,
+    tag_directives_end: *mut YamlTagDirectiveT,
+    implicit: bool,
+) -> Success {
+    let current_block: u64;
+    let mark = YamlMarkT {
+        index: 0_u64,
+        line: 0_u64,
+        column: 0_u64,
+    };
+    let mut version_directive_copy: *mut YamlVersionDirectiveT =
+        ptr::null_mut::<YamlVersionDirectiveT>();
+    struct TagDirectivesCopy {
+        start: *mut YamlTagDirectiveT,
+        end: *mut YamlTagDirectiveT,
+        top: *mut YamlTagDirectiveT,
+    }
+    let mut tag_directives_copy = TagDirectivesCopy {
+        start: ptr::null_mut::<YamlTagDirectiveT>(),
+        end: ptr::null_mut::<YamlTagDirectiveT>(),
+        top: ptr::null_mut::<YamlTagDirectiveT>(),
+    };
+    let mut value = YamlTagDirectiveT {
+        handle: ptr::null_mut::<yaml_char_t>(),
+        prefix: ptr::null_mut::<yaml_char_t>(),
+    };
+    __assert!(!event.is_null());
+    __assert!(
+        !tag_directives_start.is_null()
+            && !tag_directives_end.is_null()
+            || tag_directives_start == tag_directives_end
+    );
+    if !version_directive.is_null() {
+        version_directive_copy =
+            yaml_malloc(
+                size_of::<YamlVersionDirectiveT>() as libc::c_ulong
+            ) as *mut YamlVersionDirectiveT;
+        (*version_directive_copy).major = (*version_directive).major;
+        (*version_directive_copy).minor = (*version_directive).minor;
+    }
+    if tag_directives_start != tag_directives_end {
+        let mut tag_directive: *mut YamlTagDirectiveT;
+        STACK_INIT!(tag_directives_copy, YamlTagDirectiveT);
+        tag_directive = tag_directives_start;
+        loop {
+            if tag_directive == tag_directives_end {
+                current_block = 16203760046146113240;
+                break;
+            }
+            __assert!(!((*tag_directive).handle).is_null());
+            __assert!(!((*tag_directive).prefix).is_null());
+            if yaml_check_utf8(
+                (*tag_directive).handle,
+                strlen((*tag_directive).handle as *mut libc::c_char),
+            )
+            .fail
+            {
+                current_block = 14964981520188694172;
+                break;
+            }
+            if yaml_check_utf8(
+                (*tag_directive).prefix,
+                strlen((*tag_directive).prefix as *mut libc::c_char),
+            )
+            .fail
+            {
+                current_block = 14964981520188694172;
+                break;
+            }
+            value.handle = yaml_strdup((*tag_directive).handle);
+            value.prefix = yaml_strdup((*tag_directive).prefix);
+            if value.handle.is_null() || value.prefix.is_null() {
+                current_block = 14964981520188694172;
+                break;
+            }
+            PUSH!(tag_directives_copy, value);
+            value.handle = ptr::null_mut::<yaml_char_t>();
+            value.prefix = ptr::null_mut::<yaml_char_t>();
+            tag_directive = tag_directive.wrapping_offset(1);
+        }
+    } else {
+        current_block = 16203760046146113240;
+    }
+    if current_block != 14964981520188694172 {
+        memset(
+            event as *mut libc::c_void,
+            0,
+            size_of::<YamlEventT>() as libc::c_ulong,
+        );
+        (*event).type_ = YamlDocumentStartEvent;
+        (*event).start_mark = mark;
+        (*event).end_mark = mark;
+        let fresh164 = addr_of_mut!(
+            (*event).data.document_start.version_directive
+        );
+        *fresh164 = version_directive_copy;
+        let fresh165 = addr_of_mut!(
+            (*event).data.document_start.tag_directives.start
+        );
+        *fresh165 = tag_directives_copy.start;
+        let fresh166 = addr_of_mut!(
+            (*event).data.document_start.tag_directives.end
+        );
+        *fresh166 = tag_directives_copy.top;
+        (*event).data.document_start.implicit = implicit;
+        return OK;
+    }
+    yaml_free(version_directive_copy as *mut libc::c_void);
+    while !STACK_EMPTY!(tag_directives_copy) {
+        let value = POP!(tag_directives_copy);
+        yaml_free(value.handle as *mut libc::c_void);
+        yaml_free(value.prefix as *mut libc::c_void);
+    }
+    STACK_DEL!(tag_directives_copy);
+    yaml_free(value.handle as *mut libc::c_void);
+    yaml_free(value.prefix as *mut libc::c_void);
+    FAIL
+}

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,6 +1,6 @@
-use crate::api::yaml_check_utf8;
-use crate::api::yaml_stack_extend;
 use crate::externs::{memcpy, memset, strlen};
+use crate::internal::yaml_check_utf8;
+use crate::internal::yaml_stack_extend;
 use crate::memory::{yaml_free, yaml_malloc, yaml_strdup};
 use crate::ops::ForceAdd;
 use crate::success::{Success, FAIL, OK};

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -1,6 +1,7 @@
-use crate::api::{yaml_free, yaml_malloc};
+use crate::api::yaml_free;
 use crate::externs::{memset, strcmp};
 use crate::fmt::WriteToPtr;
+use crate::memory::yaml_malloc;
 use crate::ops::ForceMul as _;
 use crate::success::{Success, FAIL, OK};
 use crate::yaml::{

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -1,6 +1,6 @@
-use crate::memory::yaml_free;
 use crate::externs::{memset, strcmp};
 use crate::fmt::WriteToPtr;
+use crate::memory::yaml_free;
 use crate::memory::yaml_malloc;
 use crate::ops::ForceMul as _;
 use crate::success::{Success, FAIL, OK};

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -1,4 +1,4 @@
-use crate::api::yaml_free;
+use crate::memory::yaml_free;
 use crate::externs::{memset, strcmp};
 use crate::fmt::WriteToPtr;
 use crate::memory::yaml_malloc;

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -1,8 +1,6 @@
-use crate::api::{
-    yaml_queue_extend, yaml_stack_extend, yaml_strdup,
-};
-use crate::memory::yaml_free;
+use crate::api::{yaml_queue_extend, yaml_stack_extend};
 use crate::externs::{strcmp, strlen, strncmp};
+use crate::memory::{yaml_free, yaml_strdup};
 use crate::ops::{ForceAdd as _, ForceMul as _};
 use crate::success::{Success, FAIL, OK};
 use crate::yaml::{size_t, yaml_char_t, YamlStringT};

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -1,5 +1,5 @@
-use crate::api::{yaml_queue_extend, yaml_stack_extend};
 use crate::externs::{strcmp, strlen, strncmp};
+use crate::internal::{yaml_queue_extend, yaml_stack_extend};
 use crate::memory::{yaml_free, yaml_strdup};
 use crate::ops::{ForceAdd as _, ForceMul as _};
 use crate::success::{Success, FAIL, OK};

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -1,6 +1,7 @@
 use crate::api::{
-    yaml_free, yaml_queue_extend, yaml_stack_extend, yaml_strdup,
+    yaml_queue_extend, yaml_stack_extend, yaml_strdup,
 };
+use crate::memory::yaml_free;
 use crate::externs::{strcmp, strlen, strncmp};
 use crate::ops::{ForceAdd as _, ForceMul as _};
 use crate::success::{Success, FAIL, OK};

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,0 +1,205 @@
+use crate::{
+    externs::memmove,
+    libc,
+    memory::yaml_realloc,
+    ops::{ForceAdd as _, ForceMul as _},
+    success::{Success, FAIL, OK},
+    yaml::{size_t, yaml_char_t},
+    PointerExt,
+};
+
+/// Extend a stack by reallocating and copying the existing data.
+///
+/// This function is used to grow a stack when more space is needed.
+///
+/// # Safety
+///
+/// - This function is unsafe because it directly calls the system's `realloc` function,
+///   which can lead to undefined behaviour if misused.
+/// - The caller must ensure that `start`, `top`, and `end` are valid pointers into the
+///   same allocated memory block.
+/// - The caller must ensure that the memory block being extended is large enough to
+///   accommodate the new size.
+/// - The caller is responsible for properly freeing the extended memory block using
+///   the corresponding `yaml_free` function when it is no longer needed.
+///
+pub unsafe fn yaml_stack_extend(
+    start: *mut *mut libc::c_void,
+    top: *mut *mut libc::c_void,
+    end: *mut *mut libc::c_void,
+) {
+    let new_start: *mut libc::c_void = yaml_realloc(
+        *start,
+        (((*end as *mut libc::c_char)
+            .c_offset_from(*start as *mut libc::c_char)
+            as libc::c_long)
+            .force_mul(2_i64)) as size_t,
+    );
+    *top = (new_start as *mut libc::c_char).wrapping_offset(
+        (*top as *mut libc::c_char)
+            .c_offset_from(*start as *mut libc::c_char)
+            as libc::c_long as isize,
+    ) as *mut libc::c_void;
+    *end = (new_start as *mut libc::c_char).wrapping_offset(
+        (((*end as *mut libc::c_char)
+            .c_offset_from(*start as *mut libc::c_char)
+            as libc::c_long)
+            .force_mul(2_i64)) as isize,
+    ) as *mut libc::c_void;
+    *start = new_start;
+}
+
+/// Extend a queue by reallocating and copying the existing data.
+///
+/// This function is used to grow a queue when more space is needed.
+///
+/// # Safety
+///
+/// - This function is unsafe because it directly calls the system's `realloc` and
+///   `memmove` functions, which can lead to undefined behaviour if misused.
+/// - The caller must ensure that `start`, `head`, `tail`, and `end` are valid pointers
+///   into the same allocated memory block.
+/// - The caller must ensure that the memory block being extended is large enough to
+///   accommodate the new size.
+/// - The caller is responsible for properly freeing the extended memory block using
+///   the corresponding `yaml_free` function when it is no longer needed.
+///
+pub unsafe fn yaml_queue_extend(
+    start: *mut *mut libc::c_void,
+    head: *mut *mut libc::c_void,
+    tail: *mut *mut libc::c_void,
+    end: *mut *mut libc::c_void,
+) {
+    if *start == *head && *tail == *end {
+        let new_start: *mut libc::c_void = yaml_realloc(
+            *start,
+            (((*end as *mut libc::c_char)
+                .c_offset_from(*start as *mut libc::c_char)
+                as libc::c_long)
+                .force_mul(2_i64)) as size_t,
+        );
+        *head = (new_start as *mut libc::c_char).wrapping_offset(
+            (*head as *mut libc::c_char)
+                .c_offset_from(*start as *mut libc::c_char)
+                as libc::c_long as isize,
+        ) as *mut libc::c_void;
+        *tail = (new_start as *mut libc::c_char).wrapping_offset(
+            (*tail as *mut libc::c_char)
+                .c_offset_from(*start as *mut libc::c_char)
+                as libc::c_long as isize,
+        ) as *mut libc::c_void;
+        *end = (new_start as *mut libc::c_char).wrapping_offset(
+            (((*end as *mut libc::c_char)
+                .c_offset_from(*start as *mut libc::c_char)
+                as libc::c_long)
+                .force_mul(2_i64)) as isize,
+        ) as *mut libc::c_void;
+        *start = new_start;
+    }
+    if *tail == *end {
+        if *head != *tail {
+            memmove(
+                *start,
+                *head,
+                (*tail as *mut libc::c_char)
+                    .c_offset_from(*head as *mut libc::c_char)
+                    as libc::c_ulong,
+            );
+        }
+        *tail = (*start as *mut libc::c_char).wrapping_offset(
+            (*tail as *mut libc::c_char)
+                .c_offset_from(*head as *mut libc::c_char)
+                as libc::c_long as isize,
+        ) as *mut libc::c_void;
+        *head = *start;
+    }
+}
+
+/// Checks if the provided UTF-8 encoded string is valid according to the UTF-8 specification.
+///
+/// # Parameters
+///
+/// * `start`: A pointer to the start of the UTF-8 encoded string.
+/// * `length`: The length of the UTF-8 encoded string in bytes.
+///
+/// # Return
+///
+/// Returns `Success::OK` if the string is valid UTF-8, otherwise returns `Success::FAIL`.
+///
+/// # Safety
+///
+/// - `start` must be a valid, non-null pointer to a null-terminated UTF-8 string.
+/// - The UTF-8 encoded string must be properly formatted and not contain any invalid characters.
+/// - The string must be properly null-terminated.
+/// - The string must not contain any invalid characters or sequences.
+///
+pub unsafe fn yaml_check_utf8(
+    start: *const yaml_char_t,
+    length: size_t,
+) -> Success {
+    let end: *const yaml_char_t =
+        start.wrapping_offset(length as isize);
+    let mut pointer: *const yaml_char_t = start;
+
+    while pointer < end {
+        let mut octet: libc::c_uchar;
+        let mut value: libc::c_uint;
+        let mut k: size_t;
+
+        octet = *pointer;
+        let width: libc::c_uint = if octet & 0x80 == 0 {
+            1
+        } else if octet & 0xE0 == 0xC0 {
+            2
+        } else if octet & 0xF0 == 0xE0 {
+            3
+        } else if octet & 0xF8 == 0xF0 {
+            4
+        } else {
+            0
+        } as libc::c_uint;
+
+        value = if octet & 0x80 == 0 {
+            octet & 0x7F
+        } else if octet & 0xE0 == 0xC0 {
+            octet & 0x1F
+        } else if octet & 0xF0 == 0xE0 {
+            octet & 0xF
+        } else if octet & 0xF8 == 0xF0 {
+            octet & 0x7
+        } else {
+            0
+        } as libc::c_uint;
+
+        if width == 0 {
+            return FAIL;
+        }
+
+        if pointer.wrapping_offset(width as isize) > end {
+            return FAIL;
+        }
+
+        k = 1_u64;
+        while k < width as libc::c_ulong {
+            octet = *pointer.wrapping_offset(k as isize);
+            if octet & 0xC0 != 0x80 {
+                return FAIL;
+            }
+            value =
+                (value << 6).force_add((octet & 0x3F) as libc::c_uint);
+            k = k.force_add(1);
+        }
+
+        if !(width == 1
+            || width == 2 && value >= 0x80
+            || width == 3 && value >= 0x800
+            || width == 4 && value >= 0x10000)
+        {
+            return FAIL;
+        }
+
+        pointer = pointer.wrapping_offset(width as isize);
+    }
+
+    OK
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@
 //! [09]: https://codecov.io/gh/sebastienrousseau/libyml
 //! [10]: https://github.com/sebastienrousseau/libyml/actions?query=branch%3Amaster
 //! [build-badge]: https://img.shields.io/github/actions/workflow/status/sebastienrousseau/libyml/release.yml?branch=master&style=for-the-badge&logo=github
-//! [codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&token=Q9KJ6XXL67&logo=codecov
+//! [codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&token=yc9s578xIk&logo=codecov
 //! [crates-badge]: https://img.shields.io/crates/v/libyml.svg?style=for-the-badge&color=fc8d62&logo=rust
 //! [libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.3-orange.svg?style=for-the-badge
 //! [docs-badge]: https://img.shields.io/badge/docs.rs-libyml-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,21 @@
 extern crate alloc;
 use core::mem::size_of;
 
-mod libc {
+/// This module contains declarations for C library functions.
+///
+/// # Purpose
+///
+/// This module provides declarations for C library functions that are used in the LibYAML library.
+/// These declarations are necessary for interfacing with the C library functions from Rust.
+///
+/// # Parameters
+///
+/// None.
+///
+/// # Return Value
+///
+/// This module does not return any value. It only contains declarations for C library functions.
+pub mod libc {
     pub(crate) use core::ffi::c_void;
     pub(crate) use core::primitive::{
         i32 as c_int, i64 as c_long, i8 as c_char, u32 as c_uint,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,6 +484,9 @@ pub mod loader;
 /// Decode module for LibYML
 pub mod decode;
 
+/// Document module for LibYML
+pub mod document;
+
 /// Memory module for LibYML
 pub mod memory;
 mod ops;
@@ -497,13 +500,7 @@ mod writer;
 pub mod yaml;
 
 pub use crate::api::{
-    yaml_alias_event_initialize, yaml_document_add_mapping,
-    yaml_document_add_scalar, yaml_document_add_sequence,
-    yaml_document_append_mapping_pair,
-    yaml_document_append_sequence_item, yaml_document_delete,
-    yaml_document_end_event_initialize, yaml_document_get_node,
-    yaml_document_get_root_node, yaml_document_initialize,
-    yaml_document_start_event_initialize, yaml_emitter_delete,
+    yaml_alias_event_initialize, yaml_emitter_delete,
     yaml_emitter_initialize, yaml_emitter_set_break,
     yaml_emitter_set_canonical, yaml_emitter_set_encoding,
     yaml_emitter_set_indent, yaml_emitter_set_output,
@@ -518,6 +515,10 @@ pub use crate::api::{
     yaml_stream_start_event_initialize, yaml_token_delete,
 };
 pub use crate::decode::{yaml_parser_delete, yaml_parser_initialize};
+pub use crate::document::{
+    yaml_document_delete, yaml_document_get_node,
+    yaml_document_get_root_node, yaml_document_initialize,
+};
 pub use crate::dumper::{
     yaml_emitter_close, yaml_emitter_dump, yaml_emitter_open,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ pub mod externs {
         let size = HEADER.force_add(size.force_into());
         let layout = Layout::from_size_align(size, MALLOC_ALIGN)
             .ok()
-            .unwrap_or_else(|| return die());
+            .unwrap_or_else(die);
         let memory = rust::alloc(layout);
         if memory.is_null() {
             return die();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! libyml = "0.0.3"
+//! libyml = "0.0.4"
 //! ```
 //!
 //! Release notes are available under [GitHub releases][05].
@@ -136,7 +136,7 @@
 //! [build-badge]: https://img.shields.io/github/actions/workflow/status/sebastienrousseau/libyml/release.yml?branch=master&style=for-the-badge&logo=github
 //! [codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&token=yc9s578xIk&logo=codecov
 //! [crates-badge]: https://img.shields.io/crates/v/libyml.svg?style=for-the-badge&color=fc8d62&logo=rust
-//! [libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.3-orange.svg?style=for-the-badge
+//! [libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.4-orange.svg?style=for-the-badge
 //! [docs-badge]: https://img.shields.io/badge/docs.rs-libyml-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs
 //! [github-badge]: https://img.shields.io/badge/github-sebastienrousseau/libyml-8da0cb?style=for-the-badge&labelColor=555555&logo=github
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,29 @@ pub mod externs {
         dest
     }
 
-    pub(crate) unsafe fn memset(
+    /// Sets the first `count` bytes of the memory block pointed to by `dest` to the specified `ch` byte.
+    ///
+    /// # Purpose
+    ///
+    /// This function fills a block of memory with a specified byte value. It is commonly used to initialize or clear memory.
+    ///
+    /// # Parameters
+    ///
+    /// - `dest`: A pointer to the memory block to be filled.
+    /// - `ch`: The byte value to fill the memory block with.
+    /// - `count`: The number of bytes to fill in the memory block.
+    ///
+    /// # Return Value
+    ///
+    /// The function returns a pointer to the memory block (`dest`) after filling it.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it directly manipulates raw memory. The caller must ensure that:
+    /// - `dest` is a valid pointer to a memory block.
+    /// - `count` is not greater than the size of the memory block pointed to by `dest`.
+    /// - The memory block pointed to by `dest` is properly aligned and initialized.
+    pub unsafe fn memset(
         dest: *mut libc::c_void,
         ch: libc::c_int,
         count: libc::c_ulong,
@@ -323,21 +345,6 @@ pub mod externs {
             strlen(rhs) as usize,
         );
         lhs.cmp(rhs) as libc::c_int
-    }
-
-    pub(crate) unsafe fn strdup(
-        src: *const libc::c_char,
-    ) -> *mut libc::c_char {
-        if src.is_null() {
-            return die();
-        }
-        let len = strlen(src);
-        let dest = malloc(len + 1);
-        if dest.is_null() {
-            return die();
-        }
-        memcpy(dest, src.cast(), len + 1);
-        dest.cast()
     }
 
     pub(crate) unsafe fn strlen(
@@ -465,6 +472,10 @@ pub mod utils;
 
 /// API module for LibYML
 pub mod api;
+
+/// String module for LibYML
+pub mod string;
+
 mod dumper;
 mod emitter;
 /// Loader module for LibYML

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,9 +169,9 @@ mod externs {
     use crate::ops::{die, ForceAdd as _, ForceInto as _};
     use alloc::alloc::{self as rust, Layout};
     use core::mem::MaybeUninit;
+    use core::mem::{align_of, size_of};
     use core::ptr;
     use core::slice;
-    use core::mem::{size_of, align_of};
 
     const HEADER: usize = {
         let need_len = size_of::<usize>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,6 @@
 #![crate_type = "lib"]
 
 extern crate alloc;
-
 use core::mem::size_of;
 
 mod libc {
@@ -169,12 +168,13 @@ pub mod externs {
     use crate::libc;
     use crate::ops::{die, ForceAdd as _, ForceInto as _};
     use alloc::alloc::{self as rust, Layout};
-    use core::mem::{self, MaybeUninit};
+    use core::mem::MaybeUninit;
+    use core::mem::{align_of, size_of};
     use core::ptr;
     use core::slice;
 
     const HEADER: usize = {
-        let need_len = mem::size_of::<usize>();
+        let need_len = size_of::<usize>();
         // Round up to multiple of MALLOC_ALIGN.
         (need_len + MALLOC_ALIGN - 1) & !(MALLOC_ALIGN - 1)
     };
@@ -182,8 +182,8 @@ pub mod externs {
     // `max_align_t` may be bigger than this, but libyaml does not use `long
     // double` or u128.
     const MALLOC_ALIGN: usize = {
-        let int_align = mem::align_of::<libc::c_ulong>();
-        let ptr_align = mem::align_of::<usize>();
+        let int_align = align_of::<libc::c_ulong>();
+        let ptr_align = align_of::<usize>();
         if int_align >= ptr_align {
             int_align
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,7 +454,8 @@ mod ops;
 mod parser;
 mod reader;
 mod scanner;
-mod success;
+/// Success and Failure types for LibYML
+pub mod success;
 mod writer;
 /// YAML API module for LibYML
 pub mod yaml;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,10 @@ mod dumper;
 mod emitter;
 /// Loader module for LibYML
 pub mod loader;
+
+/// Decode module for LibYML
+pub mod decode;
+
 /// Memory module for LibYML
 pub mod memory;
 mod ops;
@@ -506,14 +510,14 @@ pub use crate::api::{
     yaml_emitter_set_output_string, yaml_emitter_set_unicode,
     yaml_emitter_set_width, yaml_event_delete,
     yaml_mapping_end_event_initialize,
-    yaml_mapping_start_event_initialize, yaml_parser_delete,
-    yaml_parser_initialize, yaml_parser_set_encoding,
+    yaml_mapping_start_event_initialize, yaml_parser_set_encoding,
     yaml_parser_set_input, yaml_parser_set_input_string,
     yaml_scalar_event_initialize, yaml_sequence_end_event_initialize,
     yaml_sequence_start_event_initialize,
     yaml_stream_end_event_initialize,
     yaml_stream_start_event_initialize, yaml_token_delete,
 };
+pub use crate::decode::{yaml_parser_delete, yaml_parser_initialize};
 pub use crate::dumper::{
     yaml_emitter_close, yaml_emitter_dump, yaml_emitter_open,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,12 +168,13 @@ mod externs {
     use crate::libc;
     use crate::ops::{die, ForceAdd as _, ForceInto as _};
     use alloc::alloc::{self as rust, Layout};
-    use core::mem::{self, MaybeUninit};
+    use core::mem::MaybeUninit;
     use core::ptr;
     use core::slice;
+    use core::mem::{size_of, align_of};
 
     const HEADER: usize = {
-        let need_len = mem::size_of::<usize>();
+        let need_len = size_of::<usize>();
         // Round up to multiple of MALLOC_ALIGN.
         (need_len + MALLOC_ALIGN - 1) & !(MALLOC_ALIGN - 1)
     };
@@ -181,8 +182,8 @@ mod externs {
     // `max_align_t` may be bigger than this, but libyaml does not use `long
     // double` or u128.
     const MALLOC_ALIGN: usize = {
-        let int_align = mem::align_of::<libc::c_ulong>();
-        let ptr_align = mem::align_of::<usize>();
+        let int_align = align_of::<libc::c_ulong>();
+        let ptr_align = align_of::<usize>();
         if int_align >= ptr_align {
             int_align
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,8 @@ mod macros;
 pub mod api;
 mod dumper;
 mod emitter;
-mod loader;
+/// Loader module for LibYML
+pub mod loader;
 mod ops;
 mod parser;
 mod reader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,8 @@ mod libc {
 }
 
 #[macro_use]
-mod externs {
+/// This module contains external functions and types used by LibYML.
+pub mod externs {
     use crate::libc;
     use crate::ops::{die, ForceAdd as _, ForceInto as _};
     use alloc::alloc::{self as rust, Layout};
@@ -227,7 +228,12 @@ mod externs {
         memory.add(HEADER).cast()
     }
 
-    pub(crate) unsafe fn free(ptr: *mut libc::c_void) {
+    /// Deallocates the memory pointed to by `ptr`.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it can cause undefined behavior if the `ptr` is not a valid pointer.
+    pub unsafe fn free(ptr: *mut libc::c_void) {
         let memory = ptr.cast::<u8>().sub(HEADER);
         let size = memory.cast::<usize>().read();
         let layout =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,12 +465,12 @@ pub mod utils;
 
 /// API module for LibYML
 pub mod api;
-/// Memory module for LibYML
-pub mod memory;
 mod dumper;
 mod emitter;
 /// Loader module for LibYML
 pub mod loader;
+/// Memory module for LibYML
+pub mod memory;
 mod ops;
 mod parser;
 mod reader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,6 +487,9 @@ pub mod decode;
 /// Document module for LibYML
 pub mod document;
 
+/// Internal module for LibYML
+pub mod internal;
+
 /// Memory module for LibYML
 pub mod memory;
 mod ops;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! libyml = "0.0.4"
+//! libyml = "0.0.3"
 //! ```
 //!
 //! Release notes are available under [GitHub releases][05].
@@ -136,7 +136,7 @@
 //! [build-badge]: https://img.shields.io/github/actions/workflow/status/sebastienrousseau/libyml/release.yml?branch=master&style=for-the-badge&logo=github
 //! [codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/libyml?style=for-the-badge&token=yc9s578xIk&logo=codecov
 //! [crates-badge]: https://img.shields.io/crates/v/libyml.svg?style=for-the-badge&color=fc8d62&logo=rust
-//! [libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.4-orange.svg?style=for-the-badge
+//! [libs-badge]: https://img.shields.io/badge/lib.rs-v0.0.3-orange.svg?style=for-the-badge
 //! [docs-badge]: https://img.shields.io/badge/docs.rs-libyml-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs
 //! [github-badge]: https://img.shields.io/badge/github-sebastienrousseau/libyml-8da0cb?style=for-the-badge&labelColor=555555&logo=github
 
@@ -163,19 +163,18 @@ mod libc {
     };
 }
 
+/// Externs for libyaml
 #[macro_use]
-/// This module contains external functions and types used by LibYML.
 pub mod externs {
     use crate::libc;
     use crate::ops::{die, ForceAdd as _, ForceInto as _};
     use alloc::alloc::{self as rust, Layout};
-    use core::mem::MaybeUninit;
-    use core::mem::{align_of, size_of};
+    use core::mem::{self, MaybeUninit};
     use core::ptr;
     use core::slice;
 
     const HEADER: usize = {
-        let need_len = size_of::<usize>();
+        let need_len = mem::size_of::<usize>();
         // Round up to multiple of MALLOC_ALIGN.
         (need_len + MALLOC_ALIGN - 1) & !(MALLOC_ALIGN - 1)
     };
@@ -183,8 +182,8 @@ pub mod externs {
     // `max_align_t` may be bigger than this, but libyaml does not use `long
     // double` or u128.
     const MALLOC_ALIGN: usize = {
-        let int_align = align_of::<libc::c_ulong>();
-        let ptr_align = align_of::<usize>();
+        let int_align = mem::align_of::<libc::c_ulong>();
+        let ptr_align = mem::align_of::<usize>();
         if int_align >= ptr_align {
             int_align
         } else {
@@ -228,11 +227,7 @@ pub mod externs {
         memory.add(HEADER).cast()
     }
 
-    /// Deallocates the memory pointed to by `ptr`.
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe because it can cause undefined behavior if the `ptr` is not a valid pointer.
+    /// Free memory.
     pub unsafe fn free(ptr: *mut libc::c_void) {
         let memory = ptr.cast::<u8>().sub(HEADER);
         let size = memory.cast::<usize>().read();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,8 +459,14 @@ impl<T> PointerExt for *mut T {
 #[macro_use]
 mod macros;
 
+/// Macros module for LibYML
+#[macro_use]
+pub mod utils;
+
 /// API module for LibYML
 pub mod api;
+/// Memory module for LibYML
+pub mod memory;
 mod dumper;
 mod emitter;
 /// Loader module for LibYML

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,5 +1,5 @@
-use crate::api::yaml_stack_extend;
 use crate::externs::{memset, strcmp};
+use crate::internal::yaml_stack_extend;
 use crate::memory::{yaml_free, yaml_malloc, yaml_strdup};
 use crate::success::{Success, FAIL, OK};
 use crate::yaml::yaml_char_t;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -97,7 +97,29 @@ pub unsafe fn yaml_parser_load(
     FAIL
 }
 
-unsafe fn yaml_parser_set_composer_error(
+/// Sets the error type to `YamlComposerError` and stores the problem and its mark.
+///
+/// # Parameters
+///
+/// * `parser`: A mutable pointer to the `YamlParserT` struct.
+/// * `problem`: A pointer to a constant C string representing the problem.
+/// * `problem_mark`: A `YamlMarkT` struct representing the mark where the problem occurred.
+///
+/// # Return
+///
+/// Returns `FAIL` to indicate an error.
+///
+/// # Safety
+///
+/// - `parser` must be a valid, non-null pointer to a properly initialized `YamlParserT` struct.
+/// - `problem` must be a valid, non-null pointer to a constant C string.
+/// - `problem_mark` must be a valid `YamlMarkT` struct.
+/// - The `YamlParserT` struct must be properly aligned and have the expected memory layout.
+/// - The `problem` string must be null-terminated.
+/// - The `problem_mark` struct must be properly initialized.
+/// - The caller must handle the error and clean up any resources.
+///
+pub unsafe fn yaml_parser_set_composer_error(
     parser: *mut YamlParserT,
     problem: *const libc::c_char,
     problem_mark: YamlMarkT,

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,7 +1,6 @@
-use crate::api::{
-    yaml_free, yaml_malloc, yaml_stack_extend, yaml_strdup,
-};
+use crate::api::{yaml_free, yaml_stack_extend, yaml_strdup};
 use crate::externs::{memset, strcmp};
+use crate::memory::yaml_malloc;
 use crate::success::{Success, FAIL, OK};
 use crate::yaml::yaml_char_t;
 use crate::{

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,6 +1,7 @@
-use crate::api::{yaml_free, yaml_stack_extend, yaml_strdup};
+use crate::api::{yaml_stack_extend, yaml_strdup};
 use crate::externs::{memset, strcmp};
 use crate::memory::yaml_malloc;
+use crate::memory::yaml_free;
 use crate::success::{Success, FAIL, OK};
 use crate::yaml::yaml_char_t;
 use crate::{

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,7 +1,6 @@
-use crate::api::{yaml_stack_extend, yaml_strdup};
+use crate::api::yaml_stack_extend;
 use crate::externs::{memset, strcmp};
-use crate::memory::yaml_malloc;
-use crate::memory::yaml_free;
+use crate::memory::{yaml_free, yaml_malloc, yaml_strdup};
 use crate::success::{Success, FAIL, OK};
 use crate::yaml::yaml_char_t;
 use crate::{

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -93,7 +93,10 @@ pub unsafe fn yaml_malloc(size: size_t) -> *mut c_void {
 ///     }
 /// }
 /// ```
-pub unsafe fn yaml_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void {
+pub unsafe fn yaml_realloc(
+    ptr: *mut c_void,
+    size: size_t,
+) -> *mut c_void {
     if !ptr.is_null() {
         realloc(ptr, size)
     } else {
@@ -183,7 +186,8 @@ pub unsafe fn yaml_strdup(str: *const yaml_char_t) -> *mut yaml_char_t {
     }
     let len = strlen(str as *const libc::c_char) as usize;
     let new_size = (len + 1) * core::mem::size_of::<yaml_char_t>();
-    let new_str = malloc(new_size.try_into().unwrap()) as *mut yaml_char_t;
+    let new_str =
+        malloc(new_size.try_into().unwrap()) as *mut yaml_char_t;
     if new_str.is_null() {
         return ptr::null_mut();
     }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,0 +1,192 @@
+use crate::{
+    externs::{free, malloc, realloc, strlen},
+    libc,
+    yaml::{size_t, yaml_char_t},
+};
+use core::ptr;
+use libc::c_void;
+
+/// Allocate memory using the system's `malloc` function.
+///
+/// This function allocates `size` bytes of uninitialized memory and returns a pointer to it.
+///
+/// # Arguments
+///
+/// * `size` - The number of bytes to allocate.
+///
+/// # Returns
+///
+/// Returns a pointer to the allocated memory, or a null pointer if the allocation failed.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It directly calls the system's `malloc` function, which is not memory-safe.
+/// - The caller must ensure that the allocated memory is properly freed using `yaml_free`.
+/// - The caller is responsible for initializing the allocated memory before use.
+///
+/// # Examples
+///
+/// ```
+/// use libyml::memory::yaml_malloc;
+/// use libyml::yaml::size_t;
+/// use libyml::memory::yaml_free;
+///
+/// unsafe {
+///     let size: size_t = 1024;
+///     let ptr = yaml_malloc(size);
+///     if !ptr.is_null() {
+///         // Use the allocated memory
+///         // ...
+///         yaml_free(ptr);
+///     }
+/// }
+/// ```
+pub unsafe fn yaml_malloc(size: size_t) -> *mut c_void {
+    malloc(size)
+}
+
+/// Reallocate memory using the system's `realloc` function.
+///
+/// This function changes the size of the memory block pointed to by `ptr` to `size` bytes.
+///
+/// # Arguments
+///
+/// * `ptr` - A pointer to the memory block to reallocate. If null, this function behaves like `yaml_malloc`.
+/// * `size` - The new size of the memory block in bytes.
+///
+/// # Returns
+///
+/// Returns a pointer to the reallocated memory, which may be different from `ptr`, or a null pointer if the reallocation failed.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It directly calls the system's `realloc` function, which is not memory-safe.
+/// - The caller must ensure that `ptr` is either null or was previously allocated by `yaml_malloc` or `yaml_realloc`.
+/// - The caller must ensure that the reallocated memory is properly freed using `yaml_free`.
+/// - The contents of the reallocated memory beyond the original size are undefined.
+///
+/// # Note
+///
+/// If the reallocation fails, the original memory block is left untouched and a null pointer is returned.
+///
+/// # Examples
+///
+/// ```
+/// use libyml::memory::{yaml_malloc, yaml_realloc, yaml_free};
+/// use libyml::yaml::size_t;
+///
+/// unsafe {
+///     let mut size: size_t = 1024;
+///     let mut ptr = yaml_malloc(size);
+///     if !ptr.is_null() {
+///         // Use the allocated memory
+///         // ...
+///         size = 2048;
+///         ptr = yaml_realloc(ptr, size);
+///         if !ptr.is_null() {
+///             // Use the reallocated memory
+///             // ...
+///             yaml_free(ptr);
+///         }
+///     }
+/// }
+/// ```
+pub unsafe fn yaml_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void {
+    if !ptr.is_null() {
+        realloc(ptr, size)
+    } else {
+        malloc(size)
+    }
+}
+
+/// Free memory allocated by `yaml_malloc` or `yaml_realloc`.
+///
+/// This function deallocates the memory previously allocated by `yaml_malloc` or `yaml_realloc`.
+///
+/// # Arguments
+///
+/// * `ptr` - A pointer to the memory block to free. If null, no operation is performed.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It directly calls the system's `free` function, which is not memory-safe.
+/// - The caller must ensure that `ptr` was allocated by `yaml_malloc` or `yaml_realloc`.
+/// - After calling this function, `ptr` becomes invalid and must not be used.
+///
+/// # Examples
+///
+/// ```
+/// use libyml::memory::{yaml_malloc, yaml_free};
+/// use libyml::yaml::size_t;
+///
+/// unsafe {
+///     let size: size_t = 1024;
+///     let ptr = yaml_malloc(size);
+///     if !ptr.is_null() {
+///         // Use the allocated memory
+///         // ...
+///         yaml_free(ptr);
+///         // ptr is now invalid and must not be used
+///     }
+/// }
+/// ```
+pub unsafe fn yaml_free(ptr: *mut c_void) {
+    if !ptr.is_null() {
+        free(ptr);
+    }
+}
+
+/// Duplicate a string using the system's `malloc` function and manual copy due to type mismatch.
+///
+/// This function creates a new copy of the input string, allocating new memory for it.
+///
+/// # Arguments
+///
+/// * `str` - A pointer to the null-terminated string to duplicate.
+///
+/// # Returns
+///
+/// Returns a pointer to the newly allocated string, or a null pointer if the allocation failed or the input was null.
+///
+/// # Safety
+///
+/// This function is unsafe because:
+/// - It involves memory allocation and raw pointer manipulation.
+/// - The caller must ensure that `str` is a valid, null-terminated string.
+/// - The caller is responsible for freeing the returned pointer using `yaml_free`.
+///
+/// # Examples
+///
+/// ```
+/// use libyml::memory::{yaml_strdup, yaml_free};
+/// use libyml::yaml::yaml_char_t;
+/// use core::ffi::c_void;
+///
+/// unsafe {
+///     // Note: The cast to *const yaml_char_t is necessary because yaml_char_t
+///     // might not be the same as u8 on all systems.
+///     let original: *const yaml_char_t = b"Hello, world!\0".as_ptr() as *const yaml_char_t;
+///     let copy = yaml_strdup(original);
+///     if !copy.is_null() {
+///         // Use the duplicated string
+///         // ...
+///         yaml_free(copy as *mut c_void);
+///     }
+/// }
+/// ```
+pub unsafe fn yaml_strdup(str: *const yaml_char_t) -> *mut yaml_char_t {
+    if str.is_null() {
+        return ptr::null_mut();
+    }
+    let len = strlen(str as *const libc::c_char) as usize;
+    let new_size = (len + 1) * core::mem::size_of::<yaml_char_t>();
+    let new_str = malloc(new_size.try_into().unwrap()) as *mut yaml_char_t;
+    if new_str.is_null() {
+        return ptr::null_mut();
+    }
+    ptr::copy_nonoverlapping(str, new_str, len + 1);
+    new_str
+}

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -3,7 +3,7 @@ use crate::{
     libc,
     yaml::{size_t, yaml_char_t},
 };
-use core::ptr;
+use core::{mem::size_of, ptr};
 use libc::c_void;
 
 /// Allocate memory using the system's `malloc` function.
@@ -185,7 +185,7 @@ pub unsafe fn yaml_strdup(str: *const yaml_char_t) -> *mut yaml_char_t {
         return ptr::null_mut();
     }
     let len = strlen(str as *const libc::c_char) as usize;
-    let new_size = (len + 1) * core::mem::size_of::<yaml_char_t>();
+    let new_size = (len + 1) * size_of::<yaml_char_t>();
     let new_str =
         malloc(new_size.try_into().unwrap()) as *mut yaml_char_t;
     if new_str.is_null() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,6 @@
-use crate::api::{yaml_stack_extend, yaml_strdup};
+use crate::api::yaml_stack_extend;
 use crate::externs::{memcpy, memset, strcmp, strlen};
-use crate::memory::yaml_malloc;
-use crate::memory::yaml_free;
+use crate::memory::{yaml_free, yaml_malloc, yaml_strdup};
 use crate::ops::ForceAdd as _;
 use crate::scanner::yaml_parser_fetch_more_tokens;
 use crate::success::{Success, FAIL, OK};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,5 @@
-use crate::api::yaml_stack_extend;
 use crate::externs::{memcpy, memset, strcmp, strlen};
+use crate::internal::yaml_stack_extend;
 use crate::memory::{yaml_free, yaml_malloc, yaml_strdup};
 use crate::ops::ForceAdd as _;
 use crate::scanner::yaml_parser_fetch_more_tokens;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -66,24 +66,41 @@ unsafe fn skip_token(parser: *mut YamlParserT) {
 
 /// Parse the input stream and produce the next parsing event.
 ///
-/// Call the function subsequently to produce a sequence of events corresponding
-/// to the input stream. The initial event has the type YamlStreamStartEvent
-/// while the ending event has the type YamlStreamEndEvent.
-///
-/// An application is responsible for freeing any buffers associated with the
-/// produced event object using the yaml_event_delete() function.
-///
-/// An application must not alternate the calls of yaml_parser_parse() with the
-/// calls of yaml_parser_scan() or yaml_parser_load(). Doing this will break the
-/// parser.
+/// This function should be called repeatedly to produce a sequence of events
+/// corresponding to the input stream. The initial event will be of type
+/// `YamlStreamStartEvent`, and the final event will be of type `YamlStreamEndEvent`.
 ///
 /// # Safety
 ///
-/// - `parser` must be a valid, non-null pointer to a properly initialized `YamlParserT` struct.
-/// - `event` must be a valid, non-null pointer to a `YamlEventT` struct that can be safely written to.
-/// - The `YamlParserT` and `YamlEventT` structs must be properly aligned and have the expected memory layout.
-/// - The caller must call `yaml_event_delete` to free any buffers associated with the produced event object.
-/// - The caller must not alternate calls to `yaml_parser_parse` with calls to `yaml_parser_scan` or `yaml_parser_load` on the same `YamlParserT` instance.
+/// This function is unsafe because:
+/// - It operates on raw pointers.
+/// - It assumes certain memory layouts and alignments.
+/// - It may cause undefined behavior if the input pointers are invalid or if the
+///   function is misused.
+///
+/// # Arguments
+///
+/// * `parser` - A pointer to a properly initialized `YamlParserT` struct.
+/// * `event` - A pointer to a `YamlEventT` struct that will be filled with the next event.
+///
+/// # Returns
+///
+/// Returns `OK` if an event was successfully parsed, or `FAIL` if:
+/// - The stream has ended (stream_end_produced is true)
+/// - There's an existing error in the parser
+/// - The parser is in the end state
+///
+/// # Errors
+///
+/// This function will return `FAIL` if any of the above error conditions are met.
+/// The caller should check the parser's error state for more details on the failure.
+///
+/// # Notes
+///
+/// - The caller is responsible for freeing any buffers associated with the produced
+///   event using the `yaml_event_delete()` function.
+/// - Do not alternate calls to `yaml_parser_parse()` with calls to `yaml_parser_scan()`
+///   or `yaml_parser_load()`. Doing so will break the parser.
 ///
 pub unsafe fn yaml_parser_parse(
     parser: *mut YamlParserT,
@@ -96,11 +113,14 @@ pub unsafe fn yaml_parser_parse(
         0,
         size_of::<YamlEventT>() as libc::c_ulong,
     );
-    if (*parser).stream_end_produced
-        || (*parser).error != YamlNoError
-        || (*parser).state == YamlParseEndState
-    {
-        return OK;
+    if (*parser).stream_end_produced {
+        return FAIL;
+    }
+    if (*parser).error != YamlNoError {
+        return FAIL;
+    }
+    if (*parser).state == YamlParseEndState {
+        return FAIL;
     }
     yaml_parser_state_machine(parser, event)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,6 @@
-use crate::api::{
-    yaml_free, yaml_malloc, yaml_stack_extend, yaml_strdup,
-};
+use crate::api::{yaml_free, yaml_stack_extend, yaml_strdup};
 use crate::externs::{memcpy, memset, strcmp, strlen};
+use crate::memory::yaml_malloc;
 use crate::ops::ForceAdd as _;
 use crate::scanner::yaml_parser_fetch_more_tokens;
 use crate::success::{Success, FAIL, OK};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,7 @@
-use crate::api::{yaml_free, yaml_stack_extend, yaml_strdup};
+use crate::api::{yaml_stack_extend, yaml_strdup};
 use crate::externs::{memcpy, memset, strcmp, strlen};
 use crate::memory::yaml_malloc;
+use crate::memory::yaml_free;
 use crate::ops::ForceAdd as _;
 use crate::scanner::yaml_parser_fetch_more_tokens;
 use crate::success::{Success, FAIL, OK};

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,9 +1,10 @@
 use crate::api::{
-    yaml_free, yaml_queue_extend, yaml_stack_extend,
+    yaml_queue_extend, yaml_stack_extend,
     yaml_string_extend, yaml_string_join,
 };
 use crate::externs::{memcpy, memmove, memset, strcmp, strlen};
 use crate::memory::yaml_malloc;
+use crate::memory::yaml_free;
 use crate::ops::{ForceAdd as _, ForceMul as _};
 use crate::reader::yaml_parser_update_buffer;
 use crate::success::{Success, FAIL, OK};

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,8 +1,9 @@
 use crate::api::{
-    yaml_free, yaml_malloc, yaml_queue_extend, yaml_stack_extend,
+    yaml_free, yaml_queue_extend, yaml_stack_extend,
     yaml_string_extend, yaml_string_join,
 };
 use crate::externs::{memcpy, memmove, memset, strcmp, strlen};
+use crate::memory::yaml_malloc;
 use crate::ops::{ForceAdd as _, ForceMul as _};
 use crate::reader::yaml_parser_update_buffer;
 use crate::success::{Success, FAIL, OK};

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,12 +1,10 @@
-use crate::api::{
-    yaml_queue_extend, yaml_stack_extend,
-    yaml_string_extend, yaml_string_join,
-};
+use crate::api::{yaml_queue_extend, yaml_stack_extend};
 use crate::externs::{memcpy, memmove, memset, strcmp, strlen};
-use crate::memory::yaml_malloc;
 use crate::memory::yaml_free;
+use crate::memory::yaml_malloc;
 use crate::ops::{ForceAdd as _, ForceMul as _};
 use crate::reader::yaml_parser_update_buffer;
+use crate::string::{yaml_string_extend, yaml_string_join};
 use crate::success::{Success, FAIL, OK};
 use crate::yaml::{
     ptrdiff_t, size_t, yaml_char_t, YamlStringT, NULL_STRING,

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,5 +1,5 @@
-use crate::api::{yaml_queue_extend, yaml_stack_extend};
 use crate::externs::{memcpy, memmove, memset, strcmp, strlen};
+use crate::internal::{yaml_queue_extend, yaml_stack_extend};
 use crate::memory::yaml_free;
 use crate::memory::yaml_malloc;
 use crate::ops::{ForceAdd as _, ForceMul as _};

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,0 +1,98 @@
+use crate::{
+    externs::memset,
+    libc,
+    memory::{yaml_realloc, yaml_strdup},
+    yaml::{size_t, yaml_char_t},
+};
+
+/// Extend a string buffer by reallocating and copying the existing data.
+///
+/// This function is used to grow a string buffer when more space is needed.
+///
+/// # Safety
+///
+/// - This function is unsafe because it directly calls the system's `realloc` and
+///   `memset` functions, which can lead to undefined behaviour if misused.
+/// - The caller must ensure that `start`, `pointer`, and `end` are valid pointers
+///   into the same allocated memory block.
+/// - The caller must ensure that the memory block being extended is large enough
+///   to accommodate the new size.
+/// - The caller is responsible for properly freeing the extended memory block using
+///   the corresponding `yaml_free` function when it is no longer needed.
+///
+pub unsafe fn yaml_string_extend(
+    start: *mut *mut yaml_char_t,
+    pointer: *mut *mut yaml_char_t,
+    end: *mut *mut yaml_char_t,
+) {
+    let current_size = (*end).offset_from(*start) as size_t;
+    let new_size = current_size * 2;
+
+    let new_start: *mut yaml_char_t =
+        yaml_realloc(*start as *mut libc::c_void, new_size)
+            as *mut yaml_char_t;
+    memset(
+        new_start.add(current_size.try_into().unwrap())
+            as *mut libc::c_void,
+        0,
+        current_size,
+    );
+
+    let offset = (*pointer).offset_from(*start);
+    *pointer = new_start.add(offset.try_into().unwrap());
+    *end = new_start.add((new_size as isize).try_into().unwrap());
+    *start = new_start;
+}
+
+/// Duplicate a null-terminated string.
+/// # Safety
+/// - This function is unsafe because it involves memory allocation.
+pub unsafe fn yaml_string_duplicate(
+    str: *const yaml_char_t,
+) -> *mut yaml_char_t {
+    yaml_strdup(str)
+}
+
+/// Join two string buffers by copying data from one to the other.
+///
+/// This function is used to concatenate two string buffers.
+///
+/// # Safety
+///
+/// - This function is unsafe because it directly calls the system's `memcpy` function,
+///   which can lead to undefined behaviour if misused.
+/// - The caller must ensure that `a_start`, `a_pointer`, `a_end`, `b_start`, `b_pointer`,
+///   and `b_end` are valid pointers into their respective allocated memory blocks.
+/// - The caller must ensure that the memory blocks being joined are large enough to
+///   accommodate the combined data.
+/// - The caller is responsible for properly freeing the joined memory block using
+///   the corresponding `yaml_free` function when it is no longer needed.
+///
+pub unsafe fn yaml_string_join(
+    a_start: *mut *mut yaml_char_t,
+    a_pointer: *mut *mut yaml_char_t,
+    a_end: *mut *mut yaml_char_t,
+    b_start: *mut *mut yaml_char_t,
+    b_pointer: *mut *mut yaml_char_t,
+    b_end: *mut *mut yaml_char_t,
+) {
+    if *b_start == *b_pointer {
+        return;
+    }
+
+    let b_length = ((*b_pointer).offset_from(*b_start))
+        .min((*b_end).offset_from(*b_start))
+        as usize;
+
+    if b_length == 0 {
+        return;
+    }
+
+    while ((*a_end).offset_from(*a_pointer) as usize) < b_length {
+        yaml_string_extend(a_start, a_pointer, a_end);
+    }
+
+    core::ptr::copy_nonoverlapping(*b_start, *a_pointer, b_length);
+
+    *a_pointer = (*a_pointer).add(b_length);
+}

--- a/src/success.rs
+++ b/src/success.rs
@@ -8,14 +8,14 @@ pub const FAIL: Success = Success { ok: false };
 
 /// Structure representing the success state of an operation.
 #[must_use]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct Success {
     /// Boolean indicating whether the operation was successful.
     pub ok: bool,
 }
 
 /// Structure representing the failure state of an operation.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct Failure {
     /// Boolean indicating whether the operation failed.
     pub fail: bool,

--- a/src/success.rs
+++ b/src/success.rs
@@ -1,27 +1,83 @@
 use core::ops::Deref;
 
-pub(crate) const OK: Success = Success { ok: true };
-pub(crate) const FAIL: Success = Success { ok: false };
+/// Constant representing a successful operation.
+pub const OK: Success = Success { ok: true };
 
+/// Constant representing a failed operation.
+pub const FAIL: Success = Success { ok: false };
+
+/// Structure representing the success state of an operation.
 #[must_use]
 #[derive(Copy, Clone, Debug)]
 pub struct Success {
+    /// Boolean indicating whether the operation was successful.
     pub ok: bool,
 }
 
+/// Structure representing the failure state of an operation.
 #[derive(Copy, Clone, Debug)]
 pub struct Failure {
+    /// Boolean indicating whether the operation failed.
     pub fail: bool,
 }
 
 impl Deref for Success {
     type Target = Failure;
 
+    /// Returns a reference to the corresponding `Failure` instance based on the success state.
     fn deref(&self) -> &Self::Target {
         if self.ok {
             &Failure { fail: false }
         } else {
             &Failure { fail: true }
         }
+    }
+}
+
+/// Checks if the given `Success` result indicates a successful operation.
+///
+/// # Arguments
+///
+/// * `result` - A `Success` struct representing the result of an operation.
+///
+/// # Returns
+///
+/// * `true` if the operation was successful.
+/// * `false` if the operation failed.
+pub fn is_success(result: Success) -> bool {
+    result.ok
+}
+
+/// Checks if the given `Success` result indicates a failure operation.
+///
+/// # Arguments
+///
+/// * `result` - A `Success` struct representing the result of an operation.
+///
+/// # Returns
+///
+/// * `true` if the operation failed.
+/// * `false` if the operation was successful.
+pub fn is_failure(result: Success) -> bool {
+    !result.ok
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_success() {
+        assert!(is_success(OK));
+        assert!(!is_success(FAIL));
+    }
+
+    #[test]
+    fn test_deref() {
+        let success = OK;
+        let failure = FAIL;
+        assert_eq!(success.deref().fail, false);
+        assert_eq!(failure.deref().fail, true);
     }
 }

--- a/src/success.rs
+++ b/src/success.rs
@@ -62,7 +62,6 @@ pub fn is_failure(result: Success) -> bool {
     !result.ok
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,7 +76,7 @@ mod tests {
     fn test_deref() {
         let success = OK;
         let failure = FAIL;
-        assert_eq!(success.deref().fail, false);
-        assert_eq!(failure.deref().fail, true);
+        assert!(!success.deref().fail);
+        assert!(failure.deref().fail);
     }
 }

--- a/src/utils/memory_macros.rs
+++ b/src/utils/memory_macros.rs
@@ -1,0 +1,189 @@
+//! Macros for memory management operations.
+//!
+//! This module provides a set of macros that wrap the unsafe memory management
+//! functions, providing a slightly safer interface while still allowing
+//! for low-level memory operations in a no_std environment.
+
+/// Allocates memory using the system's `malloc` function.
+///
+/// This macro wraps the `yaml_malloc` function, providing a more Rust-like interface.
+///
+/// # Arguments
+///
+/// * `size` - The number of bytes to allocate.
+///
+/// # Returns
+///
+/// Returns a `*mut T` pointer to the allocated memory, or `None` if the allocation failed.
+///
+/// # Safety
+///
+/// While this macro provides a safer interface than direct use of `yaml_malloc`,
+/// it is still unsafe because:
+/// - It allocates uninitialized memory.
+/// - The caller is responsible for properly freeing the allocated memory using `yaml_free!`.
+/// - The caller must ensure the allocated memory is properly initialized before use.
+///
+/// # Examples
+///
+/// ```
+/// use libyml::{yaml_malloc,yaml_free};
+///
+/// let size = 1024;
+/// unsafe {
+///     if let Some(ptr) = yaml_malloc!(u8, size) {
+///         // Use the allocated memory
+///         // ...
+///         yaml_free!(ptr);
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! yaml_malloc {
+    ($t:ty, $size:expr) => {{
+        let ptr = unsafe { $crate::memory::yaml_malloc($size) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(ptr as *mut $t)
+        }
+    }};
+}
+
+/// Reallocates memory using the system's `realloc` function.
+///
+/// This macro wraps the `yaml_realloc` function, providing a more Rust-like interface.
+///
+/// # Arguments
+///
+/// * `ptr` - A pointer to the memory block to reallocate.
+/// * `size` - The new size of the memory block in bytes.
+///
+/// # Returns
+///
+/// Returns a `*mut T` pointer to the reallocated memory, or `None` if the reallocation failed.
+///
+/// # Safety
+///
+/// While this macro provides a safer interface than direct use of `yaml_realloc`,
+/// it is still unsafe because:
+/// - It may move the memory to a new location.
+/// - The caller must ensure that `ptr` was previously allocated by `yaml_malloc!` or `yaml_realloc!`.
+/// - The caller is responsible for properly freeing the reallocated memory using `yaml_free!`.
+/// - The contents of the reallocated memory beyond the original size are undefined.
+///
+/// # Examples
+///
+/// ```
+/// use libyml::{yaml_malloc, yaml_realloc, yaml_free};
+///
+/// unsafe {
+///     let mut size = 1024;
+///     if let Some(mut ptr) = yaml_malloc!(u8, size) {
+///         // Use the allocated memory
+///         // ...
+///         size = 2048;
+///         if let Some(new_ptr) = yaml_realloc!(ptr, u8, size) {
+///             ptr = new_ptr;
+///             // Use the reallocated memory
+///             // ...
+///             yaml_free!(ptr);
+///         }
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! yaml_realloc {
+    ($ptr:expr, $t:ty, $size:expr) => {{
+        let new_ptr = unsafe { $crate::memory::yaml_realloc($ptr as *mut _, $size) };
+        if new_ptr.is_null() {
+            None
+        } else {
+            Some(new_ptr as *mut $t)
+        }
+    }};
+}
+
+/// Frees memory allocated by `yaml_malloc!` or `yaml_realloc!`.
+///
+/// This macro wraps the `yaml_free` function, providing a more Rust-like interface.
+///
+/// # Arguments
+///
+/// * `ptr` - A pointer to the memory block to free.
+///
+/// # Safety
+///
+/// While this macro provides a safer interface than direct use of `yaml_free`,
+/// it is still unsafe because:
+/// - The caller must ensure that `ptr` was allocated by `yaml_malloc!` or `yaml_realloc!`.
+/// - After calling this macro, `ptr` becomes invalid and must not be used.
+///
+/// # Examples
+///
+/// ```
+/// use libyml::{yaml_malloc, yaml_free};
+///
+/// unsafe {
+///     let size = 1024;
+///     if let Some(ptr) = yaml_malloc!(u8, size) {
+///         // Use the allocated memory
+///         // ...
+///         yaml_free!(ptr);
+///         // ptr is now invalid and must not be used
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! yaml_free {
+    ($ptr:expr) => {
+        unsafe { $crate::memory::yaml_free($ptr as *mut _) }
+    };
+}
+
+/// Duplicates a string using the system's `malloc` function and manual copy.
+///
+/// This macro wraps the `yaml_strdup` function, providing a more Rust-like interface.
+///
+/// # Arguments
+///
+/// * `str` - A pointer to the null-terminated string to duplicate.
+///
+/// # Returns
+///
+/// Returns a `*mut yaml_char_t` pointer to the newly allocated string, or `None` if the allocation failed or the input was null.
+///
+/// # Safety
+///
+/// While this macro provides a safer interface than direct use of `yaml_strdup`,
+/// it is still unsafe because:
+/// - It involves memory allocation and raw pointer manipulation.
+/// - The caller must ensure that `str` is a valid, null-terminated string.
+/// - The caller is responsible for freeing the returned pointer using `yaml_free!`.
+///
+/// # Examples
+///
+/// ```
+/// use libyml::yaml::yaml_char_t;
+/// use libyml::{yaml_strdup, yaml_free};
+///
+/// unsafe {
+///     let original = b"Hello, world!\0".as_ptr() as *const yaml_char_t;
+///     if let Some(copy) = yaml_strdup!(original) {
+///         // Use the duplicated string
+///         // ...
+///         yaml_free!(copy);
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! yaml_strdup {
+    ($str:expr) => {{
+        let new_str = unsafe { $crate::memory::yaml_strdup($str) };
+        if new_str.is_null() {
+            None
+        } else {
+            Some(new_str)
+        }
+    }};
+}

--- a/src/utils/memory_macros.rs
+++ b/src/utils/memory_macros.rs
@@ -95,7 +95,9 @@ macro_rules! yaml_malloc {
 #[macro_export]
 macro_rules! yaml_realloc {
     ($ptr:expr, $t:ty, $size:expr) => {{
-        let new_ptr = unsafe { $crate::memory::yaml_realloc($ptr as *mut _, $size) };
+        let new_ptr = unsafe {
+            $crate::memory::yaml_realloc($ptr as *mut _, $size)
+        };
         if new_ptr.is_null() {
             None
         } else {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,2 @@
+/// A macro for `memory_macros` module.
+pub mod memory_macros;

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -20,6 +20,17 @@ pub struct YamlVersionDirectiveT {
     pub minor: libc::c_int,
 }
 
+impl YamlVersionDirectiveT {
+    /// Constructor for `YamlVersionDirectiveT`.
+    pub fn new(major: libc::c_int, minor: libc::c_int) -> Self {
+        YamlVersionDirectiveT {
+            major,
+            minor,
+            // Initialize any future fields with their default values
+        }
+    }
+}
+
 /// The tag directive data.
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
@@ -1414,5 +1425,17 @@ impl Default for YamlAliasDataT {
             index: 0,
             mark: YamlMarkT::default(),
         }
+    }
+}
+
+impl Default for YamlNodeTypeT {
+    fn default() -> Self {
+        YamlNoNode
+    }
+}
+
+impl Default for YamlEmitterStateT {
+    fn default() -> Self {
+        YamlEmitterStateT::YamlEmitStreamStartState
     }
 }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -214,7 +214,7 @@ pub struct YamlTokenT {
     pub end_mark: YamlMarkT,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(C)]
 /// The data structure for YAML tokens.
 pub struct UnnamedYamlTokenTData {
@@ -286,7 +286,7 @@ pub struct UnnamedYamlTokenTdataScalar {
 }
 
 /// Represents the version directive in a YAML document.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(C)]
 #[non_exhaustive]
 pub struct UnnamedYamlTokenTdataVersionDirective {
@@ -825,7 +825,7 @@ impl Deref for YamlParserT {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(C)]
 pub(crate) struct UnnamedYamlParserTInput {
     /// String input data.
@@ -1020,7 +1020,7 @@ impl Deref for YamlEmitterT {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(C)]
 pub(crate) struct UnnamedYamlEmitterTOutput {
     /// String output data.
@@ -1244,28 +1244,12 @@ impl Default for UnnamedYamlEmitterTOutputString {
     }
 }
 
-impl Default for UnnamedYamlEmitterTOutput {
-    fn default() -> Self {
-        UnnamedYamlEmitterTOutput {
-            string: UnnamedYamlEmitterTOutputString::default(),
-        }
-    }
-}
-
 impl Default for UnnamedYamlParserTInputString {
     fn default() -> Self {
         UnnamedYamlParserTInputString {
             start: ptr::null(),
             end: ptr::null(),
             current: ptr::null(),
-        }
-    }
-}
-
-impl Default for UnnamedYamlParserTInput {
-    fn default() -> Self {
-        UnnamedYamlParserTInput {
-            string: UnnamedYamlParserTInputString::default(),
         }
     }
 }
@@ -1304,20 +1288,6 @@ impl Default for YamlTokenT {
             data: UnnamedYamlTokenTData::default(),
             start_mark: YamlMarkT::default(),
             end_mark: YamlMarkT::default(),
-        }
-    }
-}
-
-impl Default for UnnamedYamlTokenTData {
-    fn default() -> Self {
-        UnnamedYamlTokenTData {
-            stream_start: UnnamedYamlTokenTdataStreamStart::default(),
-            alias: UnnamedYamlTokenTdataAlias::default(),
-            anchor: UnnamedYamlTokenTdataAnchor::default(),
-            tag: UnnamedYamlTokenTdataTag::default(),
-            scalar: UnnamedYamlTokenTdataScalar::default(),
-            version_directive: UnnamedYamlTokenTdataVersionDirective::default(),
-            tag_directive: UnnamedYamlTokenTdataTagDirective::default(),
         }
     }
 }
@@ -1361,15 +1331,6 @@ impl Default for UnnamedYamlTokenTdataScalar {
             value: ptr::null_mut(),
             length: 0,
             style: YamlScalarStyleT::YamlAnyScalarStyle,
-        }
-    }
-}
-
-impl Default for UnnamedYamlTokenTdataVersionDirective {
-    fn default() -> Self {
-        UnnamedYamlTokenTdataVersionDirective {
-            major: 0,
-            minor: 0,
         }
     }
 }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -5,7 +5,7 @@ use core::ptr::{self, addr_of};
 pub(crate) use self::{
     YamlEncodingT::*, YamlEventTypeT::*, YamlNodeTypeT::*,
 };
-pub(crate) use core::primitive::{
+pub use core::primitive::{
     i64 as ptrdiff_t, u64 as size_t, u8 as yaml_char_t,
 };
 

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -10,7 +10,7 @@ pub(crate) use core::primitive::{
 };
 
 /// The version directive data.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(C)]
 #[non_exhaustive]
 pub struct YamlVersionDirectiveT {
@@ -66,7 +66,7 @@ pub enum YamlBreakT {
 #[repr(u32)]
 #[non_exhaustive]
 pub enum YamlErrorTypeT {
-    /// No error is produced.
+    /// No error.
     YamlNoError = 0,
     /// Cannot allocate or reallocate a block of memory.
     YamlMemoryError = 1,
@@ -84,8 +84,14 @@ pub enum YamlErrorTypeT {
     YamlEmitterError = 7,
 }
 
+impl Default for YamlErrorTypeT {
+    fn default() -> Self {
+        YamlErrorTypeT::YamlNoError
+    }
+}
+
 /// The pointer position.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(C)]
 #[non_exhaustive]
 pub struct YamlMarkT {
@@ -201,58 +207,6 @@ pub struct YamlTokenT {
     /// The token type.
     pub type_: YamlTokenTypeT,
     /// The token data.
-    ///
-    /// ```
-    /// # const _: &str = stringify! {
-    /// union {
-    ///     /// The stream start (for YamlStreamStartToken).
-    ///     stream_start: struct {
-    ///         /// The stream encoding.
-    ///         encoding: YamlEncodingT,
-    ///     },
-    ///     /// The alias (for YamlAliasToken).
-    ///     alias: struct {
-    ///         /// The alias value.
-    ///         value: *mut u8,
-    ///     },
-    ///     /// The anchor (for YamlAnchorToken).
-    ///     anchor: struct {
-    ///         /// The anchor value.
-    ///         value: *mut u8,
-    ///     },
-    ///     /// The tag (for YamlTagToken).
-    ///     tag: struct {
-    ///         /// The tag handle.
-    ///         handle: *mut u8,
-    ///         /// The tag suffix.
-    ///         suffix: *mut u8,
-    ///     },
-    ///     /// The scalar value (for YamlScalarToken).
-    ///     scalar: struct {
-    ///         /// The scalar value.
-    ///         value: *mut u8,
-    ///         /// The length of the scalar value.
-    ///         length: u64,
-    ///         /// The scalar style.
-    ///         style: YamlScalarStyleT,
-    ///     },
-    ///     /// The version directive (for YamlVersionDirectiveToken).
-    ///     version_directive: struct {
-    ///         /// The major version number.
-    ///         major: i32,
-    ///         /// The minor version number.
-    ///         minor: i32,
-    ///     },
-    ///     /// The tag directive (for YamlTagDirectiveToken).
-    ///     tag_directive: struct {
-    ///         /// The tag handle.
-    ///         handle: *mut u8,
-    ///         /// The tag prefix.
-    ///         prefix: *mut u8,
-    ///     },
-    /// }
-    /// # };
-    /// ```
     pub data: UnnamedYamlTokenTData,
     /// The beginning of the token.
     pub start_mark: YamlMarkT,
@@ -390,81 +344,6 @@ pub struct YamlEventT {
     /// The event type.
     pub type_: YamlEventTypeT,
     /// The event data.
-    ///
-    /// ```
-    /// # const _: &str = stringify! {
-    /// union {
-    ///     /// The stream parameters (for YamlStreamStartEvent).
-    ///     stream_start: struct {
-    ///         /// The document encoding.
-    ///         encoding: YamlEncodingT,
-    ///     },
-    ///     /// The document parameters (for YamlDocumentStartEvent).
-    ///     document_start: struct {
-    ///         /// The version directive.
-    ///         version_directive: *mut YamlVersionDirectiveT,
-    ///         /// The list of tag directives.
-    ///         tag_directives: struct {
-    ///             /// The beginning of the tag directives list.
-    ///             start: *mut YamlTagDirectiveT,
-    ///             /// The end of the tag directives list.
-    ///             end: *mut YamlTagDirectiveT,
-    ///         },
-    ///         /// Is the document indicator implicit?
-    ///         implicit: i32,
-    ///     },
-    ///     /// The document end parameters (for YamlDocumentEndEvent).
-    ///     document_end: struct {
-    ///         /// Is the document end indicator implicit?
-    ///         implicit: i32,
-    ///     },
-    ///     /// The alias parameters (for YamlAliasEvent).
-    ///     alias: struct {
-    ///         /// The anchor.
-    ///         anchor: *mut u8,
-    ///     },
-    ///     /// The scalar parameters (for YamlScalarEvent).
-    ///     scalar: struct {
-    ///         /// The anchor.
-    ///         anchor: *mut u8,
-    ///         /// The tag.
-    ///         tag: *mut u8,
-    ///         /// The scalar value.
-    ///         value: *mut u8,
-    ///         /// The length of the scalar value.
-    ///         length: u64,
-    ///         /// Is the tag optional for the plain style?
-    ///         plain_implicit: i32,
-    ///         /// Is the tag optional for any non-plain style?
-    ///         quoted_implicit: i32,
-    ///         /// The scalar style.
-    ///         style: YamlScalarStyleT,
-    ///     },
-    ///     /// The sequence parameters (for YamlSequenceStartEvent).
-    ///     sequence_start: struct {
-    ///         /// The anchor.
-    ///         anchor: *mut u8,
-    ///         /// The tag.
-    ///         tag: *mut u8,
-    ///         /// Is the tag optional?
-    ///         implicit: i32,
-    ///         /// The sequence style.
-    ///         style: YamlSequenceStyleT,
-    ///     },
-    ///     /// The mapping parameters (for YamlMappingStartEvent).
-    ///     mapping_start: struct {
-    ///         /// The anchor.
-    ///         anchor: *mut u8,
-    ///         /// The tag.
-    ///         tag: *mut u8,
-    ///         /// Is the tag optional?
-    ///         implicit: i32,
-    ///         /// The mapping style.
-    ///         style: YamlMappingStyleT,
-    ///     },
-    /// }
-    /// # };
-    /// ```
     pub data: UnnamedYamlEventTData,
     /// The beginning of the event.
     pub start_mark: YamlMarkT,
@@ -619,36 +498,6 @@ pub struct YamlNodeT {
     /// The node tag.
     pub tag: *mut yaml_char_t,
     /// The node data.
-    ///
-    /// ```
-    /// # const _: &str = stringify! {
-    /// union {
-    ///     /// The scalar parameters (for YamlScalarNode).
-    ///     scalar: struct {
-    ///         /// The scalar value.
-    ///         value: *mut u8,
-    ///         /// The length of the scalar value.
-    ///         length: u64,
-    ///         /// The scalar style.
-    ///         style: YamlScalarStyleT,
-    ///     },
-    ///     /// The sequence parameters (for YamlSequenceNode).
-    ///     sequence: struct {
-    ///         /// The stack of sequence items.
-    ///         items: YamlStackT<YamlNodeItemT>,
-    ///         /// The sequence style.
-    ///         style: YamlSequenceStyleT,
-    ///     },
-    ///     /// The mapping parameters (for YamlMappingNode).
-    ///     mapping: struct {
-    ///         /// The stack of mapping pairs (key, value).
-    ///         pairs: YamlStackT<YamlNodePairT>,
-    ///         /// The mapping style.
-    ///         style: YamlMappingStyleT,
-    ///     },
-    /// }
-    /// # };
-    /// ```
     pub data: UnnamedYamlNodeTData,
     /// The beginning of the node.
     pub start_mark: YamlMarkT,
@@ -727,17 +576,6 @@ pub struct YamlDocumentT {
     /// The version directive.
     pub version_directive: *mut YamlVersionDirectiveT,
     /// The list of tag directives.
-    ///
-    /// ```
-    /// # const _: &str = stringify! {
-    /// struct {
-    ///     /// The beginning of the tag directives list.
-    ///     start: *mut YamlTagDirectiveT,
-    ///     /// The end of the tag directives list.
-    ///     end: *mut YamlTagDirectiveT,
-    /// }
-    /// # };
-    /// ```
     pub tag_directives: UnnamedYamlDocumentTTagDirectives,
     /// Is the document start indicator implicit?
     pub start_implicit: bool,
@@ -777,7 +615,7 @@ pub type YamlReadHandlerT = unsafe fn(
 ) -> libc::c_int;
 
 /// This structure holds information about a potential simple key.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[repr(C)]
 #[non_exhaustive]
 pub struct YamlSimpleKeyT {
@@ -1288,16 +1126,20 @@ impl<T> YamlBufferT<T> {
     }
 }
 
-// impl<T> Copy for YamlBufferT<T> {}
-// impl<T> Clone for YamlBufferT<T> {
-//     fn clone(&self) -> Self {
-//         *self
-//     }
-// }
+impl<T> Default for YamlBufferT<T> {
+    fn default() -> Self {
+        YamlBufferT {
+            start: ptr::null_mut(),
+            end: ptr::null_mut(),
+            pointer: ptr::null_mut(),
+            last: ptr::null_mut(),
+        }
+    }
+}
 
+/// The beginning of the stack.
 #[derive(Debug)]
 #[repr(C)]
-/// The beginning of the stack.
 pub struct YamlStackT<T> {
     /// The beginning of the stack.
     pub start: *mut T,
@@ -1314,6 +1156,7 @@ impl<T> Clone for YamlStackT<T> {
     }
 }
 
+/// The beginning of the queue.
 #[derive(Debug)]
 #[repr(C)]
 pub(crate) struct YamlQueueT<T> {
@@ -1331,5 +1174,284 @@ impl<T> Copy for YamlQueueT<T> {}
 impl<T> Clone for YamlQueueT<T> {
     fn clone(&self) -> Self {
         *self
+    }
+}
+
+impl<T: Default> Default for YamlQueueT<T> {
+    fn default() -> Self {
+        YamlQueueT {
+            start: ptr::null_mut(),
+            end: ptr::null_mut(),
+            head: ptr::null_mut(),
+            tail: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for YamlStringT {
+    fn default() -> Self {
+        YamlStringT {
+            start: ptr::null_mut(),
+            end: ptr::null_mut(),
+            pointer: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for UnnamedYamlEmitterTScalarData {
+    fn default() -> Self {
+        UnnamedYamlEmitterTScalarData {
+            value: ptr::null_mut(),
+            length: 0,
+            multiline: false,
+            flow_plain_allowed: false,
+            block_plain_allowed: false,
+            single_quoted_allowed: false,
+            block_allowed: false,
+            style: YamlScalarStyleT::YamlAnyScalarStyle,
+        }
+    }
+}
+
+impl Default for UnnamedYamlEmitterTTagData {
+    fn default() -> Self {
+        UnnamedYamlEmitterTTagData {
+            handle: ptr::null_mut(),
+            handle_length: 0,
+            suffix: ptr::null_mut(),
+            suffix_length: 0,
+        }
+    }
+}
+
+impl Default for UnnamedYamlEmitterTAnchorData {
+    fn default() -> Self {
+        UnnamedYamlEmitterTAnchorData {
+            anchor: ptr::null_mut(),
+            anchor_length: 0,
+            alias: false,
+        }
+    }
+}
+
+impl Default for UnnamedYamlEmitterTOutputString {
+    fn default() -> Self {
+        UnnamedYamlEmitterTOutputString {
+            buffer: ptr::null_mut(),
+            size: 0,
+            size_written: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for UnnamedYamlEmitterTOutput {
+    fn default() -> Self {
+        UnnamedYamlEmitterTOutput {
+            string: UnnamedYamlEmitterTOutputString::default(),
+        }
+    }
+}
+
+impl Default for UnnamedYamlParserTInputString {
+    fn default() -> Self {
+        UnnamedYamlParserTInputString {
+            start: ptr::null(),
+            end: ptr::null(),
+            current: ptr::null(),
+        }
+    }
+}
+
+impl Default for UnnamedYamlParserTInput {
+    fn default() -> Self {
+        UnnamedYamlParserTInput {
+            string: UnnamedYamlParserTInputString::default(),
+        }
+    }
+}
+
+impl Default for UnnamedYamlDocumentTTagDirectives {
+    fn default() -> Self {
+        UnnamedYamlDocumentTTagDirectives {
+            start: ptr::null_mut(),
+            end: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for YamlEncodingT {
+    fn default() -> Self {
+        YamlAnyEncoding
+    }
+}
+
+impl Default for YamlParserStateT {
+    fn default() -> Self {
+        YamlParserStateT::YamlParseStreamStartState
+    }
+}
+
+impl Default for YamlScalarStyleT {
+    fn default() -> Self {
+        YamlScalarStyleT::YamlAnyScalarStyle
+    }
+}
+
+impl Default for YamlTokenT {
+    fn default() -> Self {
+        YamlTokenT {
+            type_: YamlTokenTypeT::YamlNoToken,
+            data: UnnamedYamlTokenTData::default(),
+            start_mark: YamlMarkT::default(),
+            end_mark: YamlMarkT::default(),
+        }
+    }
+}
+
+impl Default for UnnamedYamlTokenTData {
+    fn default() -> Self {
+        UnnamedYamlTokenTData {
+            stream_start: UnnamedYamlTokenTdataStreamStart::default(),
+            alias: UnnamedYamlTokenTdataAlias::default(),
+            anchor: UnnamedYamlTokenTdataAnchor::default(),
+            tag: UnnamedYamlTokenTdataTag::default(),
+            scalar: UnnamedYamlTokenTdataScalar::default(),
+            version_directive: UnnamedYamlTokenTdataVersionDirective::default(),
+            tag_directive: UnnamedYamlTokenTdataTagDirective::default(),
+        }
+    }
+}
+
+impl Default for UnnamedYamlTokenTdataStreamStart {
+    fn default() -> Self {
+        UnnamedYamlTokenTdataStreamStart {
+            encoding: YamlAnyEncoding,
+        }
+    }
+}
+
+impl Default for UnnamedYamlTokenTdataAlias {
+    fn default() -> Self {
+        UnnamedYamlTokenTdataAlias {
+            value: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for UnnamedYamlTokenTdataAnchor {
+    fn default() -> Self {
+        UnnamedYamlTokenTdataAnchor {
+            value: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for UnnamedYamlTokenTdataTag {
+    fn default() -> Self {
+        UnnamedYamlTokenTdataTag {
+            handle: ptr::null_mut(),
+            suffix: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for UnnamedYamlTokenTdataScalar {
+    fn default() -> Self {
+        UnnamedYamlTokenTdataScalar {
+            value: ptr::null_mut(),
+            length: 0,
+            style: YamlScalarStyleT::YamlAnyScalarStyle,
+        }
+    }
+}
+
+impl Default for UnnamedYamlTokenTdataVersionDirective {
+    fn default() -> Self {
+        UnnamedYamlTokenTdataVersionDirective {
+            major: 0,
+            minor: 0,
+        }
+    }
+}
+
+impl Default for UnnamedYamlTokenTdataTagDirective {
+    fn default() -> Self {
+        UnnamedYamlTokenTdataTagDirective {
+            handle: ptr::null_mut(),
+            prefix: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for YamlStackT<YamlSimpleKeyT> {
+    fn default() -> Self {
+        YamlStackT {
+            start: ptr::null_mut(),
+            end: ptr::null_mut(),
+            top: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for YamlStackT<YamlTagDirectiveT> {
+    fn default() -> Self {
+        YamlStackT {
+            start: ptr::null_mut(),
+            end: ptr::null_mut(),
+            top: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for YamlStackT<YamlAliasDataT> {
+    fn default() -> Self {
+        YamlStackT {
+            start: ptr::null_mut(),
+            end: ptr::null_mut(),
+            top: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for YamlTagDirectiveT {
+    fn default() -> Self {
+        YamlTagDirectiveT {
+            handle: ptr::null_mut(),
+            prefix: ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for YamlBreakT {
+    fn default() -> Self {
+        YamlBreakT::YamlAnyBreak
+    }
+}
+
+impl Default for YamlSequenceStyleT {
+    fn default() -> Self {
+        YamlSequenceStyleT::YamlAnySequenceStyle
+    }
+}
+
+impl Default for YamlMappingStyleT {
+    fn default() -> Self {
+        YamlMappingStyleT::YamlAnyMappingStyle
+    }
+}
+
+impl Default for YamlEventTypeT {
+    fn default() -> Self {
+        YamlNoEvent
+    }
+}
+
+impl Default for YamlAliasDataT {
+    fn default() -> Self {
+        YamlAliasDataT {
+            anchor: ptr::null_mut(),
+            index: 0,
+            mark: YamlMarkT::default(),
+        }
     }
 }

--- a/tests/explicit_types.yaml
+++ b/tests/explicit_types.yaml
@@ -1,0 +1,3 @@
+integer: !!int 42
+float: !!float 3.14
+string: !!str value

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -2,7 +2,10 @@
 mod tests {
     use core::ffi::c_void;
     use libyml::api::yaml_malloc;
+    use libyml::api::yaml_strdup;
     use libyml::externs::free;
+    use std::ptr::null;
+    use std::ptr::null_mut;
 
     #[test]
     fn test_yaml_malloc() {
@@ -16,6 +19,54 @@ mod tests {
             let ptr = yaml_malloc(10);
             assert!(!ptr.is_null());
             yaml_free(ptr); // Ensure to free the allocated memory
+        }
+    }
+
+    #[test]
+    fn test_yaml_malloc_free() {
+        unsafe {
+            // Test allocation of zero bytes
+            let ptr = yaml_malloc(0);
+            assert!(!ptr.is_null());
+            yaml_free(ptr); // Ensure to free the allocated memory
+
+            // Test allocation of non-zero bytes
+            let ptr = yaml_malloc(10);
+            assert!(!ptr.is_null());
+            yaml_free(ptr); // Ensure to free the allocated memory
+        }
+    }
+
+    #[test]
+    fn test_yaml_realloc() {
+        unsafe {
+            // Test allocation of zero bytes
+            let ptr = yaml_malloc(0);
+            assert!(!ptr.is_null());
+            yaml_free(ptr); // Ensure to free the allocated memory
+
+            // Test allocation of non-zero bytes
+            let ptr = yaml_malloc(10);
+            assert!(!ptr.is_null());
+            yaml_free(ptr); // Ensure to free the allocated memory
+        }
+    }
+
+    #[test]
+    fn test_yaml_free() {
+        unsafe {
+            // Test freeing null pointer
+            let ptr = yaml_malloc(0);
+            yaml_free(ptr);
+        }
+    }
+
+    #[test]
+    fn test_yaml_strdup() {
+        unsafe {
+            // Test duplication of a null string
+            let ptr = yaml_strdup(null());
+            assert_eq!(ptr, null_mut());
         }
     }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1,0 +1,26 @@
+#[cfg(test)]
+mod tests {
+    use core::ffi::c_void;
+    use libyml::api::yaml_malloc;
+    use libyml::externs::free;
+
+    #[test]
+    fn test_yaml_malloc() {
+        unsafe {
+            // Test allocation of zero bytes
+            let ptr = yaml_malloc(0);
+            assert!(!ptr.is_null());
+            yaml_free(ptr); // Ensure to free the allocated memory
+
+            // Test allocation of non-zero bytes
+            let ptr = yaml_malloc(10);
+            assert!(!ptr.is_null());
+            yaml_free(ptr); // Ensure to free the allocated memory
+        }
+    }
+
+    // Helper function to free memory
+    unsafe fn yaml_free(ptr: *mut c_void) {
+        free(ptr);
+    }
+}

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
     use core::ffi::c_void;
-    use libyml::api::yaml_malloc;
     use libyml::api::yaml_strdup;
     use libyml::externs::free;
+    use libyml::memory::yaml_malloc;
     use std::ptr::null;
     use std::ptr::null_mut;
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
     use core::ffi::c_void;
-    use libyml::api::yaml_strdup;
     use libyml::externs::free;
     use libyml::memory::yaml_malloc;
+    use libyml::memory::yaml_strdup;
     use std::ptr::null;
     use std::ptr::null_mut;
 

--- a/tests/test_decode.rs
+++ b/tests/test_decode.rs
@@ -1,0 +1,170 @@
+#[cfg(test)]
+mod tests {
+    use core::mem::MaybeUninit;
+    use libyml::decode::yaml_parser_delete;
+    use libyml::decode::yaml_parser_initialize;
+    use libyml::YamlParserT;
+
+    /// Tests the basic initialization of a YAML parser.
+    ///
+    /// This test ensures that the `yaml_parser_initialize` function
+    /// successfully initializes a `YamlParserT` struct and returns
+    /// a successful result.
+    ///
+    /// # Safety
+    ///
+    /// This test uses unsafe code to work with raw pointers.
+    #[test]
+    fn test_yaml_parser_initialize() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            let result = yaml_parser_initialize(parser.as_mut_ptr());
+            assert!(result.ok, "Parser initialization should succeed");
+        }
+    }
+
+    /// Tests both initialization and deletion of a YAML parser.
+    ///
+    /// This test verifies that a parser can be successfully initialized
+    /// and then deleted without any errors.
+    ///
+    /// # Safety
+    ///
+    /// This test uses unsafe code to work with raw pointers and to call
+    /// functions that require manual memory management.
+    #[test]
+    fn test_yaml_parser_initialize_and_delete() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            let init_result =
+                yaml_parser_initialize(parser.as_mut_ptr());
+            assert!(
+                init_result.ok,
+                "Parser initialization should succeed"
+            );
+
+            let parser_ptr = parser.as_mut_ptr();
+            yaml_parser_delete(parser_ptr);
+            // Note: We can't test the state after deletion as it would be undefined behavior
+        }
+    }
+
+    /// Tests multiple initializations and deletions of YAML parsers.
+    ///
+    /// This test ensures that multiple parsers can be initialized and
+    /// deleted in succession without any errors, verifying the robustness
+    /// of the initialization and deletion processes.
+    ///
+    /// # Safety
+    ///
+    /// This test uses unsafe code to work with raw pointers and to call
+    /// functions that require manual memory management.
+    #[test]
+    fn test_multiple_initialize_and_delete() {
+        unsafe {
+            for i in 0..5 {
+                let mut parser = MaybeUninit::<YamlParserT>::uninit();
+                let init_result =
+                    yaml_parser_initialize(parser.as_mut_ptr());
+                assert!(init_result.ok, "Parser initialization should succeed on iteration {}", i);
+
+                let parser_ptr = parser.as_mut_ptr();
+                yaml_parser_delete(parser_ptr);
+            }
+        }
+    }
+    /// Tests the overall functionality of parser initialization and deletion.
+    ///
+    /// # Safety
+    ///
+    /// This test uses unsafe code to initialize and delete the parser.
+    #[test]
+    fn test_parser_initialization_and_deletion() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            let init_result =
+                yaml_parser_initialize(parser.as_mut_ptr());
+            assert!(
+                init_result.ok,
+                "Parser initialization should succeed"
+            );
+
+            // We can't directly test private fields, but we can ensure that
+            // initialization and deletion don't cause any crashes or panics
+            yaml_parser_delete(parser.as_mut_ptr());
+        }
+    }
+    /// Tests that using a deleted parser doesn't cause undefined behavior.
+    ///
+    /// # Safety
+    ///
+    /// This test uses unsafe code to initialize, delete, and re-initialize the parser.
+    #[test]
+    fn test_parser_after_deletion() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            let _ = yaml_parser_initialize(parser.as_mut_ptr());
+
+            let parser_ptr = parser.as_mut_ptr();
+            yaml_parser_delete(parser_ptr);
+
+            // After deletion, re-initializing should still work without issues
+            let reinit_result = yaml_parser_initialize(parser_ptr);
+            assert!(reinit_result.ok, "Parser re-initialization after deletion should succeed");
+
+            yaml_parser_delete(parser_ptr);
+        }
+    }
+    /// Tests for potential memory leaks during initialization and deletion.
+    ///
+    /// Note: This test assumes some way to track allocations. You might need to
+    /// implement or use a custom allocator for this.
+    ///
+    /// # Safety
+    ///
+    /// This test uses unsafe code to initialize and delete the parser.
+    #[test]
+    fn test_memory_leaks() {
+        unsafe {
+            // Pseudo-code: Start tracking allocations
+            // start_tracking_allocations();
+
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            yaml_parser_delete(parser.as_mut_ptr());
+
+            // Pseudo-code: Check if all allocations were freed
+            // assert!(all_allocations_freed(), "Memory leak detected");
+        }
+    }
+    /// Tests that calling delete multiple times doesn't cause issues.
+    ///
+    /// # Safety
+    ///
+    /// This test uses unsafe code to initialize and delete the parser multiple times.
+    #[test]
+    fn test_multiple_deletions() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+
+            let parser_ptr = parser.as_mut_ptr();
+            yaml_parser_delete(parser_ptr);
+            yaml_parser_delete(parser_ptr); // Second deletion shouldn't cause issues
+        }
+    }
+    /// Tests that initializing with a valid pointer succeeds.
+    ///
+    /// # Safety
+    ///
+    /// This test uses unsafe code to initialize the parser.
+    #[test]
+    fn test_yaml_parser_initialize_valid() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            let result = yaml_parser_initialize(parser.as_mut_ptr());
+            assert!(result.ok, "Parser initialization should succeed with valid pointer");
+
+            // Clean up
+            yaml_parser_delete(parser.as_mut_ptr());
+        }
+    }
+}

--- a/tests/test_decode.rs
+++ b/tests/test_decode.rs
@@ -124,8 +124,12 @@ mod tests {
     fn test_multiple_deletions() {
         unsafe {
             let mut parser = MaybeUninit::<YamlParserT>::uninit();
-            let init_result = yaml_parser_initialize(parser.as_mut_ptr());
-            assert!(init_result.ok, "Parser initialization should succeed");
+            let init_result =
+                yaml_parser_initialize(parser.as_mut_ptr());
+            assert!(
+                init_result.ok,
+                "Parser initialization should succeed"
+            );
 
             let parser_ptr = parser.as_mut_ptr();
             yaml_parser_delete(parser_ptr);
@@ -146,8 +150,12 @@ mod tests {
             // We can't track allocations without a custom allocator, so we'll just
             // test that we can initialize and delete without crashing
             let mut parser = MaybeUninit::<YamlParserT>::uninit();
-            let init_result = yaml_parser_initialize(parser.as_mut_ptr());
-            assert!(init_result.ok, "Parser initialization should succeed");
+            let init_result =
+                yaml_parser_initialize(parser.as_mut_ptr());
+            assert!(
+                init_result.ok,
+                "Parser initialization should succeed"
+            );
             yaml_parser_delete(parser.as_mut_ptr());
         }
     }

--- a/tests/test_decode.rs
+++ b/tests/test_decode.rs
@@ -115,27 +115,6 @@ mod tests {
             yaml_parser_delete(parser_ptr);
         }
     }
-    /// Tests for potential memory leaks during initialization and deletion.
-    ///
-    /// Note: This test assumes some way to track allocations. You might need to
-    /// implement or use a custom allocator for this.
-    ///
-    /// # Safety
-    ///
-    /// This test uses unsafe code to initialize and delete the parser.
-    #[test]
-    fn test_memory_leaks() {
-        unsafe {
-            // Pseudo-code: Start tracking allocations
-            // start_tracking_allocations();
-
-            let mut parser = MaybeUninit::<YamlParserT>::uninit();
-            yaml_parser_delete(parser.as_mut_ptr());
-
-            // Pseudo-code: Check if all allocations were freed
-            // assert!(all_allocations_freed(), "Memory leak detected");
-        }
-    }
     /// Tests that calling delete multiple times doesn't cause issues.
     ///
     /// # Safety
@@ -145,10 +124,31 @@ mod tests {
     fn test_multiple_deletions() {
         unsafe {
             let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            let init_result = yaml_parser_initialize(parser.as_mut_ptr());
+            assert!(init_result.ok, "Parser initialization should succeed");
 
             let parser_ptr = parser.as_mut_ptr();
             yaml_parser_delete(parser_ptr);
-            yaml_parser_delete(parser_ptr); // Second deletion shouldn't cause issues
+            // We'll remove the second deletion as it's not safe to delete an already deleted parser
+        }
+    }
+
+    /// Tests for potential memory leaks during initialization and deletion.
+    ///
+    /// Note: This test is a placeholder and doesn't actually track allocations.
+    ///
+    /// # Safety
+    ///
+    /// This test uses unsafe code to initialize and delete the parser.
+    #[test]
+    fn test_memory_leaks() {
+        unsafe {
+            // We can't track allocations without a custom allocator, so we'll just
+            // test that we can initialize and delete without crashing
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            let init_result = yaml_parser_initialize(parser.as_mut_ptr());
+            assert!(init_result.ok, "Parser initialization should succeed");
+            yaml_parser_delete(parser.as_mut_ptr());
         }
     }
     /// Tests that initializing with a valid pointer succeeds.

--- a/tests/test_document.rs
+++ b/tests/test_document.rs
@@ -1,0 +1,132 @@
+#[cfg(test)]
+mod tests {
+    use core::mem::MaybeUninit;
+    use libyml::success::OK;
+    use libyml::yaml_document_delete;
+    use libyml::yaml_document_initialize;
+    use libyml::YamlDocumentT;
+    use libyml::YamlVersionDirectiveT;
+    use std::ptr;
+
+    #[test]
+    fn test_yaml_document_initialize_non_null_document() {
+        unsafe {
+            let mut doc: YamlDocumentT =
+                MaybeUninit::zeroed().assume_init();
+            let result = yaml_document_initialize(
+                &mut doc,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                false,
+                false,
+            );
+            assert_eq!(
+                result, OK,
+                "Initialization should handle null pointers gracefully"
+            );
+            // Clean up the document to prevent memory leaks.
+            doc.cleanup();
+        }
+    }
+
+    #[test]
+    fn test_yaml_document_initialize() {
+        unsafe {
+            // Allocate a YamlDocumentT on the stack or heap (if more complex setup is needed).
+            let mut doc: YamlDocumentT =
+                MaybeUninit::zeroed().assume_init();
+            let result = yaml_document_initialize(
+                &mut doc,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                false,
+                false,
+            );
+            // Check if the initialization was successful.
+            assert!(result.ok, "Document initialization should succeed with valid pointer");
+        }
+    }
+    #[test]
+    fn test_yaml_document_delete() {
+        unsafe {
+            // Allocate a YamlDocumentT using MaybeUninit for proper initialization.
+            let mut doc: MaybeUninit<YamlDocumentT> =
+                MaybeUninit::zeroed();
+            let doc_ptr = doc.as_mut_ptr(); // Obtain a mutable pointer to the uninitialized memory.
+
+            // Initialize the document using yaml_document_initialize.
+            let init_result = yaml_document_initialize(
+                doc_ptr,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                false,
+                false,
+            );
+
+            // Assume yaml_document_initialize returns a boolean or similar, check if initialization was successful.
+            assert!(init_result == OK, "Document initialization should succeed with valid pointer");
+
+            // Since the document is now initialized, you can assume the memory pointed by doc_ptr is properly initialized.
+            let doc = doc_ptr.as_mut().unwrap(); // Convert pointer to reference, which is now safe.
+
+            // Call cleanup method
+            doc.cleanup();
+        }
+    }
+
+    #[test]
+    fn test_yaml_document_initialize_valid() {
+        unsafe {
+            let mut doc: MaybeUninit<YamlDocumentT> =
+                MaybeUninit::uninit();
+            // Create version directive using a hypothetical constructor or mutable allocation
+            let mut version_directive =
+                YamlVersionDirectiveT::new(1, 2); // Assume this constructor exists
+            let mut tag_directives = vec![]; // Example for an empty array of tag directives
+
+            let version_directive_ptr: *mut YamlVersionDirectiveT =
+                &mut version_directive;
+            let result = yaml_document_initialize(
+                doc.as_mut_ptr(),
+                version_directive_ptr,
+                tag_directives.as_mut_ptr(),
+                tag_directives.as_mut_ptr().add(tag_directives.len()),
+                true,
+                false,
+            );
+
+            assert_eq!(
+                result, OK,
+                "Initialization should succeed with valid inputs"
+            );
+            // Assume a cleanup function exists to properly free resources
+            yaml_document_delete(doc.as_mut_ptr());
+        }
+    }
+
+    #[test]
+    fn test_yaml_document_initialize_invalid() {
+        unsafe {
+            let mut doc: MaybeUninit<YamlDocumentT> =
+                MaybeUninit::uninit();
+            let result = yaml_document_initialize(
+                doc.as_mut_ptr(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                false,
+                false,
+            );
+
+            assert_eq!(
+                result, OK,
+                "Initialization should handle null pointers gracefully"
+            );
+            // Assume a cleanup function exists to properly free resources
+            yaml_document_delete(doc.as_mut_ptr());
+        }
+    }
+}

--- a/tests/test_internal.rs
+++ b/tests/test_internal.rs
@@ -1,0 +1,109 @@
+use libyml::{
+    internal::{yaml_check_utf8, yaml_queue_extend, yaml_stack_extend},
+    memory::{yaml_free, yaml_malloc},
+    success::{FAIL, OK},
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests for yaml_stack_extend function
+    #[test]
+    fn test_yaml_stack_extend() {
+        unsafe {
+            // Initialize a small stack
+            let mut start = yaml_malloc(16);
+            let mut top = start;
+            let mut end = start.add(16);
+
+            // Extend the stack
+            yaml_stack_extend(&mut start, &mut top, &mut end);
+
+            // Check if the stack size doubled
+            assert_eq!(end.offset_from(start), 32);
+
+            // Clean up
+            yaml_free(start);
+        }
+    }
+
+    /// Tests for yaml_queue_extend function
+    #[test]
+    fn test_yaml_queue_extend() {
+        unsafe {
+            // Initialize a small queue
+            let mut start = yaml_malloc(16);
+            let mut head = start;
+            let mut tail = start;
+            let mut end = start.add(32);
+
+            // Extend the queue
+            yaml_queue_extend(
+                &mut start, &mut head, &mut tail, &mut end,
+            );
+
+            // Check if the queue size doubled
+            assert_eq!(end.offset_from(start), 32);
+
+            // Clean up
+            yaml_free(start);
+        }
+    }
+
+    /// Tests for yaml_check_utf8 function
+    #[test]
+    fn test_yaml_check_utf8() {
+        unsafe {
+            // Valid UTF-8 string
+            let valid_str = "Hello, world!";
+            assert_eq!(
+                yaml_check_utf8(
+                    valid_str.as_ptr(),
+                    valid_str.len().try_into().unwrap()
+                ),
+                OK
+            );
+
+            // Invalid UTF-8 string
+            let invalid_str = [0xFF, 0xFE, 0xFD];
+            assert_eq!(
+                yaml_check_utf8(
+                    invalid_str.as_ptr(),
+                    invalid_str.len().try_into().unwrap()
+                ),
+                FAIL
+            );
+
+            // Empty string
+            let empty_str = "";
+            assert_eq!(
+                yaml_check_utf8(
+                    empty_str.as_ptr(),
+                    empty_str.len().try_into().unwrap()
+                ),
+                OK
+            );
+
+            // Multi-byte UTF-8 characters
+            let multi_byte_str = "こんにちは";
+            assert_eq!(
+                yaml_check_utf8(
+                    multi_byte_str.as_ptr(),
+                    multi_byte_str.len().try_into().unwrap()
+                ),
+                OK
+            );
+
+            // Incomplete multi-byte sequence
+            let incomplete_str = [0xE3, 0x81, 0x93, 0xE3, 0x81];
+            assert_eq!(
+                yaml_check_utf8(
+                    incomplete_str.as_ptr(),
+                    incomplete_str.len().try_into().unwrap()
+                ),
+                FAIL
+            );
+        }
+    }
+}

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -1,0 +1,96 @@
+#![no_std]
+#[cfg(test)]
+mod tests {
+    use core::mem::MaybeUninit;
+    use libyml::success::is_success;
+    use libyml::*;
+
+    /// Tests the initialization and deletion of the YAML parser.
+    #[test]
+    fn test_parser_initialize_and_delete() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            let mut parser = parser.assume_init();
+            yaml_parser_delete(&mut parser);
+        }
+    }
+
+    /// Tests setting the input string for the YAML parser.
+    #[test]
+    fn test_parser_set_input_string() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            let mut parser = parser.assume_init();
+
+            let input = b"key: value\n";
+            yaml_parser_set_input_string(&mut parser, input.as_ptr(), input.len() as u64);
+
+            yaml_parser_delete(&mut parser);
+        }
+    }
+
+    /// Tests parsing a simple YAML document.
+    #[test]
+    fn test_parser_parse_simple_document() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            let mut parser = parser.assume_init();
+
+            let input = b"key: value\n";
+            yaml_parser_set_input_string(&mut parser, input.as_ptr(), input.len() as u64);
+
+            let mut event = MaybeUninit::<YamlEventT>::uninit();
+            assert!(is_success(yaml_parser_parse(&mut parser, event.as_mut_ptr())));
+            let _event = event.assume_init();
+
+            yaml_parser_delete(&mut parser);
+        }
+    }
+
+    /// Tests parsing of a complex YAML document with nested structures.
+    #[test]
+    fn test_complex_document() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            let mut parser = parser.assume_init();
+
+            let input = b"
+            parent:
+                child1: value1
+                child2:
+                - list_item1
+                - list_item2
+            ";
+            yaml_parser_set_input_string(&mut parser, input.as_ptr(), input.len() as u64);
+
+            let mut event = MaybeUninit::<YamlEventT>::uninit();
+            assert!(is_success(yaml_parser_parse(&mut parser, event.as_mut_ptr())));
+            let _event = event.assume_init();
+
+            yaml_parser_delete(&mut parser);
+        }
+    }
+    /// Tests handling invalid YAML input.
+    #[test]
+    fn test_parser_handle_invalid_input() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            let mut parser = parser.assume_init();
+
+            let input = b"invalid_yaml";
+            yaml_parser_set_input_string(&mut parser, input.as_ptr(), input.len() as u64);
+
+            let mut event = MaybeUninit::<YamlEventT>::uninit();
+            let result = yaml_parser_parse(&mut parser, event.as_mut_ptr());
+
+            assert!(is_success(result));
+
+            yaml_parser_delete(&mut parser);
+        }
+    }
+}

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -10,7 +10,9 @@ mod tests {
     fn test_parser_initialize_and_delete() {
         unsafe {
             let mut parser = MaybeUninit::<YamlParserT>::uninit();
-            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            assert!(is_success(yaml_parser_initialize(
+                parser.as_mut_ptr()
+            )));
             let mut parser = parser.assume_init();
             yaml_parser_delete(&mut parser);
         }
@@ -21,11 +23,17 @@ mod tests {
     fn test_parser_set_input_string() {
         unsafe {
             let mut parser = MaybeUninit::<YamlParserT>::uninit();
-            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            assert!(is_success(yaml_parser_initialize(
+                parser.as_mut_ptr()
+            )));
             let mut parser = parser.assume_init();
 
             let input = b"key: value\n";
-            yaml_parser_set_input_string(&mut parser, input.as_ptr(), input.len() as u64);
+            yaml_parser_set_input_string(
+                &mut parser,
+                input.as_ptr(),
+                input.len() as u64,
+            );
 
             yaml_parser_delete(&mut parser);
         }
@@ -36,14 +44,23 @@ mod tests {
     fn test_parser_parse_simple_document() {
         unsafe {
             let mut parser = MaybeUninit::<YamlParserT>::uninit();
-            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            assert!(is_success(yaml_parser_initialize(
+                parser.as_mut_ptr()
+            )));
             let mut parser = parser.assume_init();
 
             let input = b"key: value\n";
-            yaml_parser_set_input_string(&mut parser, input.as_ptr(), input.len() as u64);
+            yaml_parser_set_input_string(
+                &mut parser,
+                input.as_ptr(),
+                input.len() as u64,
+            );
 
             let mut event = MaybeUninit::<YamlEventT>::uninit();
-            assert!(is_success(yaml_parser_parse(&mut parser, event.as_mut_ptr())));
+            assert!(is_success(yaml_parser_parse(
+                &mut parser,
+                event.as_mut_ptr()
+            )));
             let _event = event.assume_init();
 
             yaml_parser_delete(&mut parser);
@@ -55,7 +72,9 @@ mod tests {
     fn test_complex_document() {
         unsafe {
             let mut parser = MaybeUninit::<YamlParserT>::uninit();
-            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            assert!(is_success(yaml_parser_initialize(
+                parser.as_mut_ptr()
+            )));
             let mut parser = parser.assume_init();
 
             let input = b"
@@ -65,10 +84,17 @@ mod tests {
                 - list_item1
                 - list_item2
             ";
-            yaml_parser_set_input_string(&mut parser, input.as_ptr(), input.len() as u64);
+            yaml_parser_set_input_string(
+                &mut parser,
+                input.as_ptr(),
+                input.len() as u64,
+            );
 
             let mut event = MaybeUninit::<YamlEventT>::uninit();
-            assert!(is_success(yaml_parser_parse(&mut parser, event.as_mut_ptr())));
+            assert!(is_success(yaml_parser_parse(
+                &mut parser,
+                event.as_mut_ptr()
+            )));
             let _event = event.assume_init();
 
             yaml_parser_delete(&mut parser);
@@ -79,14 +105,21 @@ mod tests {
     fn test_parser_handle_invalid_input() {
         unsafe {
             let mut parser = MaybeUninit::<YamlParserT>::uninit();
-            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            assert!(is_success(yaml_parser_initialize(
+                parser.as_mut_ptr()
+            )));
             let mut parser = parser.assume_init();
 
             let input = b"invalid_yaml";
-            yaml_parser_set_input_string(&mut parser, input.as_ptr(), input.len() as u64);
+            yaml_parser_set_input_string(
+                &mut parser,
+                input.as_ptr(),
+                input.len() as u64,
+            );
 
             let mut event = MaybeUninit::<YamlEventT>::uninit();
-            let result = yaml_parser_parse(&mut parser, event.as_mut_ptr());
+            let result =
+                yaml_parser_parse(&mut parser, event.as_mut_ptr());
 
             assert!(is_success(result));
 

--- a/tests/test_loader.rs
+++ b/tests/test_loader.rs
@@ -1,0 +1,31 @@
+#[cfg(test)]
+mod tests {
+    use core::mem::MaybeUninit;
+    use libyml::*;
+    use libyml::api::{yaml_parser_initialize, yaml_parser_set_input_string};
+    use libyml::success::is_success;
+
+    #[test]
+    fn test_yaml_parser_load() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            let mut document = MaybeUninit::<YamlDocumentT>::uninit();
+            let input = b"key: value\n";
+
+            // Initialize the parser
+            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            let parser = parser.assume_init_mut();
+
+            // Set the input string
+            yaml_parser_set_input_string(parser, input.as_ptr(), input.len() as u64);
+
+            // Load the document
+            let result = yaml_parser_load(parser, document.as_mut_ptr());
+            assert!(is_success(result));
+
+            // Clean up
+            yaml_document_delete(document.as_mut_ptr());
+            yaml_parser_delete(parser);
+        }
+    }
+}

--- a/tests/test_loader.rs
+++ b/tests/test_loader.rs
@@ -1,9 +1,17 @@
 #[cfg(test)]
 mod tests {
+    use core::ffi::c_char;
     use core::mem::MaybeUninit;
-    use libyml::*;
-    use libyml::api::{yaml_parser_initialize, yaml_parser_set_input_string};
+    use libyml::api::{
+        yaml_parser_initialize, yaml_parser_set_input_string,
+    };
+    use libyml::loader::yaml_parser_set_composer_error;
     use libyml::success::is_success;
+    use libyml::yaml::YamlErrorTypeT::YamlComposerError;
+    use libyml::{
+        yaml_document_delete, yaml_parser_delete, yaml_parser_load,
+        YamlDocumentT, YamlMarkT, YamlParserT,
+    };
 
     #[test]
     fn test_yaml_parser_load() {
@@ -13,18 +21,58 @@ mod tests {
             let input = b"key: value\n";
 
             // Initialize the parser
-            assert!(is_success(yaml_parser_initialize(parser.as_mut_ptr())));
+            assert!(is_success(yaml_parser_initialize(
+                parser.as_mut_ptr()
+            )));
             let parser = parser.assume_init_mut();
 
             // Set the input string
-            yaml_parser_set_input_string(parser, input.as_ptr(), input.len() as u64);
+            yaml_parser_set_input_string(
+                parser,
+                input.as_ptr(),
+                input.len() as u64,
+            );
 
             // Load the document
-            let result = yaml_parser_load(parser, document.as_mut_ptr());
+            let result =
+                yaml_parser_load(parser, document.as_mut_ptr());
             assert!(is_success(result));
 
             // Clean up
             yaml_document_delete(document.as_mut_ptr());
+            yaml_parser_delete(parser);
+        }
+    }
+
+    // Test for yaml_parser_set_composer_error
+    #[test]
+    fn test_yaml_parser_set_composer_error() {
+        unsafe {
+            let mut parser = MaybeUninit::<YamlParserT>::uninit();
+            assert!(is_success(yaml_parser_initialize(
+                parser.as_mut_ptr()
+            )));
+            let parser = parser.assume_init_mut();
+
+            let problem =
+                b"Test problem\0" as *const u8 as *const c_char;
+            let problem_mark = YamlMarkT::default();
+
+            // Call the function that sets the error
+            let _ = yaml_parser_set_composer_error(
+                parser,
+                problem,
+                problem_mark,
+            );
+
+            // Check if the error is set correctly
+            assert_eq!(parser.error, YamlComposerError);
+            assert_eq!(parser.problem, problem);
+            assert_eq!(parser.problem_mark.index, problem_mark.index);
+            assert_eq!(parser.problem_mark.line, problem_mark.line);
+            assert_eq!(parser.problem_mark.column, problem_mark.column);
+
+            // Clean up
             yaml_parser_delete(parser);
         }
     }

--- a/tests/test_loader.rs
+++ b/tests/test_loader.rs
@@ -2,9 +2,8 @@
 mod tests {
     use core::ffi::c_char;
     use core::mem::MaybeUninit;
-    use libyml::api::{
-        yaml_parser_initialize, yaml_parser_set_input_string,
-    };
+    use libyml::api::yaml_parser_set_input_string;
+    use libyml::decode::yaml_parser_initialize;
     use libyml::loader::yaml_parser_set_composer_error;
     use libyml::success::is_success;
     use libyml::yaml::YamlErrorTypeT::YamlComposerError;

--- a/tests/test_memory.rs
+++ b/tests/test_memory.rs
@@ -1,9 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use libyml::memory::*;
-    use libyml::yaml::yaml_char_t;
-    use core::ptr;
     use core::ffi::c_void;
+    use core::ptr;
+    use libyml::memory::*;
 
     /// Tests that `yaml_malloc` successfully allocates memory.
     #[test]
@@ -63,7 +62,7 @@ mod tests {
     #[test]
     fn test_yaml_strdup() {
         unsafe {
-            let original = b"test string\0" as *const u8 as *const yaml_char_t;
+            let original = b"test string\0" as *const u8;
 
             let duped_ptr = yaml_strdup(original);
             assert!(!duped_ptr.is_null());
@@ -93,7 +92,7 @@ mod tests {
     #[test]
     fn test_yaml_strdup_empty_string() {
         unsafe {
-            let original = b"\0" as *const u8 as *const yaml_char_t;
+            let original = b"\0" as *const u8;
 
             let duped_ptr = yaml_strdup(original);
             assert!(!duped_ptr.is_null());

--- a/tests/test_memory.rs
+++ b/tests/test_memory.rs
@@ -1,0 +1,106 @@
+#[cfg(test)]
+mod tests {
+    use libyml::memory::*;
+    use libyml::yaml::yaml_char_t;
+    use core::ptr;
+    use core::ffi::c_void;
+
+    /// Tests that `yaml_malloc` successfully allocates memory.
+    #[test]
+    fn test_yaml_malloc() {
+        unsafe {
+            let ptr = yaml_malloc(10);
+            assert!(!ptr.is_null());
+            yaml_free(ptr);
+        }
+    }
+
+    /// Tests that `yaml_realloc` successfully reallocates memory.
+    #[test]
+    fn test_yaml_realloc() {
+        unsafe {
+            let ptr = yaml_malloc(10);
+            assert!(!ptr.is_null());
+
+            let new_ptr = yaml_realloc(ptr, 20);
+            assert!(!new_ptr.is_null());
+
+            yaml_free(new_ptr);
+        }
+    }
+
+    /// Tests that `yaml_realloc` behaves correctly when given a null pointer.
+    #[test]
+    fn test_yaml_realloc_null() {
+        unsafe {
+            let ptr = yaml_realloc(ptr::null_mut(), 10);
+            assert!(!ptr.is_null());
+            yaml_free(ptr);
+        }
+    }
+
+    /// Tests that `yaml_free` successfully frees allocated memory.
+    #[test]
+    fn test_yaml_free() {
+        unsafe {
+            let ptr = yaml_malloc(10);
+            assert!(!ptr.is_null());
+            yaml_free(ptr);
+            // We can't really test much after freeing, as using the pointer would be undefined behavior
+        }
+    }
+
+    /// Tests that `yaml_free` behaves correctly when given a null pointer.
+    #[test]
+    fn test_yaml_free_null() {
+        unsafe {
+            // This should not cause any errors
+            yaml_free(ptr::null_mut());
+        }
+    }
+
+    /// Tests that `yaml_strdup` correctly duplicates a string.
+    #[test]
+    fn test_yaml_strdup() {
+        unsafe {
+            let original = b"test string\0" as *const u8 as *const yaml_char_t;
+
+            let duped_ptr = yaml_strdup(original);
+            assert!(!duped_ptr.is_null());
+
+            // Compare the strings
+            let mut i = 0;
+            while *original.add(i) != 0 {
+                assert_eq!(*original.add(i), *duped_ptr.add(i));
+                i += 1;
+            }
+            assert_eq!(*duped_ptr.add(i), 0); // Null terminator
+
+            yaml_free(duped_ptr as *mut c_void);
+        }
+    }
+
+    /// Tests that `yaml_strdup` returns a null pointer when given a null pointer.
+    #[test]
+    fn test_yaml_strdup_null() {
+        unsafe {
+            let duped_ptr = yaml_strdup(ptr::null());
+            assert!(duped_ptr.is_null());
+        }
+    }
+
+    /// Tests that `yaml_strdup` correctly duplicates an empty string.
+    #[test]
+    fn test_yaml_strdup_empty_string() {
+        unsafe {
+            let original = b"\0" as *const u8 as *const yaml_char_t;
+
+            let duped_ptr = yaml_strdup(original);
+            assert!(!duped_ptr.is_null());
+
+            assert_eq!(*duped_ptr, 0); // Should only contain null terminator
+
+            yaml_free(duped_ptr as *mut c_void);
+        }
+    }
+}

--- a/tests/test_parser.rs
+++ b/tests/test_parser.rs
@@ -8,6 +8,7 @@ mod run_parser_test_suite;
 use std::fs;
 use std::path::Path;
 
+/// Test function for running parser tests from the YAML Test Suite
 fn test(id: &str) {
     let dir = Path::new("tests")
         .join("data")
@@ -27,6 +28,421 @@ fn test(id: &str) {
     let expected = fs::read_to_string(dir.join("test.event")).unwrap();
     pretty_assertions::assert_str_eq!(expected, stdout);
     assert!(output.success);
+}
+
+/// Test parsing of an empty YAML file
+#[test]
+fn test_empty_file() {
+    let temp_file = Path::new("tests").join("empty.yaml");
+    fs::write(&temp_file, "").unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    assert!(output.success, "Parser should succeed for empty file");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("+STR") && stdout.contains("-STR"),
+        "Empty file should still have stream start/end"
+    );
+
+    fs::remove_file(temp_file).unwrap();
+}
+
+/// Test parsing of a simple scalar YAML
+#[test]
+fn test_scalar_parsing() {
+    let yaml = "scalar: value";
+    let temp_file = Path::new("tests").join("temp_scalar.yaml");
+    fs::write(&temp_file, yaml).unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    println!("Actual output:\n{}", stdout);
+
+    assert!(output.success, "Parser did not exit successfully");
+
+    assert!(stdout.contains("+STR"), "Output doesn't contain '+STR'");
+    assert!(stdout.contains("+DOC"), "Output doesn't contain '+DOC'");
+    assert!(stdout.contains("+MAP"), "Output doesn't contain '+MAP'");
+    assert!(
+        stdout.contains("=VAL :scalar"),
+        "Output doesn't contain '=VAL :scalar'"
+    );
+    assert!(
+        stdout.contains("=VAL :value"),
+        "Output doesn't contain '=VAL :value'"
+    );
+    assert!(stdout.contains("-MAP"), "Output doesn't contain '-MAP'");
+    assert!(stdout.contains("-DOC"), "Output doesn't contain '-DOC'");
+    assert!(stdout.contains("-STR"), "Output doesn't contain '-STR'");
+
+    fs::remove_file(temp_file).unwrap();
+}
+
+/// Test parsing of a YAML sequence
+#[test]
+fn test_sequence_parsing() {
+    let yaml = "- item1\n- item2\n- item3";
+    let temp_file = Path::new("tests").join("temp_sequence.yaml");
+    fs::write(&temp_file, yaml).unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    println!("Actual output:\n{}", stdout);
+
+    assert!(output.success, "Parser did not exit successfully");
+
+    assert!(stdout.contains("+STR"), "Output doesn't contain '+STR'");
+    assert!(stdout.contains("+DOC"), "Output doesn't contain '+DOC'");
+    assert!(stdout.contains("+SEQ"), "Output doesn't contain '+SEQ'");
+    assert!(
+        stdout.contains("=VAL :item1"),
+        "Output doesn't contain '=VAL :item1'"
+    );
+    assert!(
+        stdout.contains("=VAL :item2"),
+        "Output doesn't contain '=VAL :item2'"
+    );
+    assert!(
+        stdout.contains("=VAL :item3"),
+        "Output doesn't contain '=VAL :item3'"
+    );
+    assert!(stdout.contains("-SEQ"), "Output doesn't contain '-SEQ'");
+    assert!(stdout.contains("-DOC"), "Output doesn't contain '-DOC'");
+    assert!(stdout.contains("-STR"), "Output doesn't contain '-STR'");
+
+    fs::remove_file(temp_file).unwrap();
+}
+
+/// Test parsing of a YAML mapping
+#[test]
+fn test_mapping_parsing() {
+    let yaml = "key1: value1\nkey2: value2";
+    let temp_file = Path::new("tests").join("temp_mapping.yaml");
+    fs::write(&temp_file, yaml).unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    println!("Actual output:\n{}", stdout);
+
+    assert!(output.success, "Parser did not exit successfully");
+
+    assert!(stdout.contains("+STR"), "Output doesn't contain '+STR'");
+    assert!(stdout.contains("+DOC"), "Output doesn't contain '+DOC'");
+    assert!(stdout.contains("+MAP"), "Output doesn't contain '+MAP'");
+    assert!(
+        stdout.contains("=VAL :key1"),
+        "Output doesn't contain '=VAL :key1'"
+    );
+    assert!(
+        stdout.contains("=VAL :value1"),
+        "Output doesn't contain '=VAL :value1'"
+    );
+    assert!(
+        stdout.contains("=VAL :key2"),
+        "Output doesn't contain '=VAL :key2'"
+    );
+    assert!(
+        stdout.contains("=VAL :value2"),
+        "Output doesn't contain '=VAL :value2'"
+    );
+    assert!(stdout.contains("-MAP"), "Output doesn't contain '-MAP'");
+    assert!(stdout.contains("-DOC"), "Output doesn't contain '-DOC'");
+    assert!(stdout.contains("-STR"), "Output doesn't contain '-STR'");
+
+    fs::remove_file(temp_file).unwrap();
+}
+
+/// Test parsing of nested YAML structures
+#[test]
+fn test_nested_structures() {
+    let yaml = "
+    outer:
+      inner:
+        - item1
+        - item2:
+            subkey: subvalue
+    ";
+    let temp_file = Path::new("tests").join("nested.yaml");
+    fs::write(&temp_file, yaml).unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.success, "Parser did not exit successfully");
+    assert!(stdout.contains("+MAP"), "Output doesn't contain '+MAP'");
+    assert!(stdout.contains("+SEQ"), "Output doesn't contain '+SEQ'");
+    assert!(
+        stdout.contains("=VAL :outer"),
+        "Output doesn't contain '=VAL :outer'"
+    );
+    assert!(
+        stdout.contains("=VAL :inner"),
+        "Output doesn't contain '=VAL :inner'"
+    );
+    assert!(
+        stdout.contains("=VAL :item1"),
+        "Output doesn't contain '=VAL :item1'"
+    );
+    assert!(
+        stdout.contains("=VAL :item2"),
+        "Output doesn't contain '=VAL :item2'"
+    );
+    assert!(
+        stdout.contains("=VAL :subkey"),
+        "Output doesn't contain '=VAL :subkey'"
+    );
+    assert!(
+        stdout.contains("=VAL :subvalue"),
+        "Output doesn't contain '=VAL :subvalue'"
+    );
+
+    fs::remove_file(temp_file).unwrap();
+}
+
+/// Test parsing of YAML with anchors and aliases
+#[test]
+fn test_anchors_and_aliases() {
+    let yaml = "
+    anchor: &anchor_value
+        key: value
+    alias: *anchor_value
+    ";
+    let temp_file = Path::new("tests").join("anchors.yaml");
+    fs::write(&temp_file, yaml).unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.success, "Parser did not exit successfully");
+    assert!(
+        stdout.contains("&anchor_value"),
+        "Output doesn't contain '&anchor_value'"
+    );
+    assert!(
+        stdout.contains("*anchor_value"),
+        "Output doesn't contain '*anchor_value'"
+    );
+
+    fs::remove_file(temp_file).unwrap();
+}
+
+/// Test parsing of YAML with multiline strings
+#[test]
+fn test_multiline_strings() {
+    let yaml = r#"
+    literal: |
+      This is a
+      multiline string
+    folded: >
+      This is another
+      multiline string
+    "#;
+    let temp_file = Path::new("tests").join("multiline.yaml");
+    fs::write(&temp_file, yaml).unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.success, "Parser did not exit successfully");
+    assert!(
+        stdout.contains("=VAL |"),
+        "Output doesn't contain literal multiline indicator"
+    );
+    assert!(
+        stdout.contains("=VAL >"),
+        "Output doesn't contain folded multiline indicator"
+    );
+
+    fs::remove_file(temp_file).unwrap();
+}
+
+/// Test parsing of YAML in flow style
+#[test]
+fn test_flow_style() {
+    let yaml = "{key1: value1, key2: [item1, item2]}";
+    let temp_file = Path::new("tests").join("flow_style.yaml");
+    fs::write(&temp_file, yaml).unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.success, "Parser did not exit successfully");
+    assert!(stdout.contains("+MAP"), "Output doesn't contain '+MAP'");
+    assert!(stdout.contains("+SEQ"), "Output doesn't contain '+SEQ'");
+    assert!(
+        stdout.contains("=VAL :key1"),
+        "Output doesn't contain '=VAL :key1'"
+    );
+    assert!(
+        stdout.contains("=VAL :value1"),
+        "Output doesn't contain '=VAL :value1'"
+    );
+    assert!(
+        stdout.contains("=VAL :key2"),
+        "Output doesn't contain '=VAL :key2'"
+    );
+    assert!(
+        stdout.contains("=VAL :item1"),
+        "Output doesn't contain '=VAL :item1'"
+    );
+    assert!(
+        stdout.contains("=VAL :item2"),
+        "Output doesn't contain '=VAL :item2'"
+    );
+
+    fs::remove_file(temp_file).unwrap();
+}
+
+/// Test parsing of YAML with Unicode characters
+#[test]
+fn test_unicode() {
+    let yaml = "unicode: 你好世界";
+    let temp_file = Path::new("tests").join("unicode.yaml");
+    fs::write(&temp_file, yaml).unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    assert!(
+        output.success,
+        "Parser should succeed for Unicode content"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("你好世界"),
+        "Unicode characters should be preserved"
+    );
+
+    fs::remove_file(temp_file).unwrap();
+}
+
+/// Test parsing of YAML with comments
+#[test]
+fn test_comments() {
+    let yaml = "key: value # This is a comment\n# This is another comment\nother: value";
+    let temp_file = Path::new("tests").join("comments.yaml");
+    fs::write(&temp_file, yaml).unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    assert!(
+        output.success,
+        "Parser should succeed for YAML with comments"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("# This is a comment"),
+        "Comments should be ignored in the output"
+    );
+
+    fs::remove_file(temp_file).unwrap();
+}
+
+/// Test parsing of YAML with directives
+#[test]
+fn test_yaml_directive() {
+    let yaml = "%YAML 1.2\n---\nkey: value";
+    let temp_file = Path::new("tests").join("directive.yaml");
+    fs::write(&temp_file, yaml).unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    println!("Actual output:\n{}", stdout);
+
+    assert!(
+        output.success,
+        "Parser should succeed for YAML with directives"
+    );
+    assert!(stdout.contains("+STR"), "Output doesn't contain '+STR'");
+    assert!(stdout.contains("+DOC"), "Output doesn't contain '+DOC'");
+    assert!(stdout.contains("+MAP"), "Output doesn't contain '+MAP'");
+    assert!(
+        stdout.contains("=VAL :key"),
+        "Output doesn't contain '=VAL :key'"
+    );
+    assert!(
+        stdout.contains("=VAL :value"),
+        "Output doesn't contain '=VAL :value'"
+    );
+    assert!(stdout.contains("-MAP"), "Output doesn't contain '-MAP'");
+    assert!(stdout.contains("-DOC"), "Output doesn't contain '-DOC'");
+    assert!(stdout.contains("-STR"), "Output doesn't contain '-STR'");
+
+    fs::remove_file(temp_file).unwrap();
+}
+
+/// Test parsing of invalid YAML
+#[test]
+fn test_invalid_yaml() {
+    let yaml = "key: : value";
+    let temp_file = Path::new("tests").join("invalid.yaml");
+    fs::write(&temp_file, yaml).unwrap();
+
+    let output = bin::run(
+        env!("CARGO_BIN_EXE_run-parser-test-suite"),
+        run_parser_test_suite::unsafe_main,
+        &temp_file,
+    );
+
+    assert!(!output.success, "Parser should fail for invalid YAML");
+
+    fs::remove_file(temp_file).unwrap();
 }
 
 libyml_test_suite::test_parser!();

--- a/tests/test_string.rs
+++ b/tests/test_string.rs
@@ -1,0 +1,238 @@
+#[cfg(test)]
+mod tests {
+    use core::ffi::c_void;
+    use core::ptr;
+    use libyml::memory::{yaml_free, yaml_malloc};
+    use libyml::string::*;
+    use libyml::yaml::yaml_char_t;
+
+    /// Tests that `yaml_string_duplicate` correctly duplicates a non-null string.
+    #[test]
+    fn test_yaml_string_duplicate() {
+        unsafe {
+            let original = b"test string\0" as *const u8;
+            let duped_ptr = yaml_string_duplicate(original);
+            assert!(!duped_ptr.is_null());
+
+            // Compare the strings
+            let mut i = 0;
+            while *original.add(i) != 0 {
+                assert_eq!(*original.add(i), *duped_ptr.add(i));
+                i += 1;
+            }
+            assert_eq!(*duped_ptr.add(i), 0); // Null terminator
+
+            yaml_free(duped_ptr as *mut c_void);
+        }
+    }
+
+    /// Tests that `yaml_string_duplicate` returns a null pointer when given a null pointer.
+    #[test]
+    fn test_yaml_string_duplicate_null() {
+        unsafe {
+            let duped_ptr = yaml_string_duplicate(ptr::null());
+            assert!(duped_ptr.is_null());
+        }
+    }
+
+    /// Tests that `yaml_string_duplicate` can correctly duplicate an empty string,
+    /// ensuring the duplicate is not null and contains only the null terminator.
+    #[test]
+    fn test_yaml_string_duplicate_empty_string() {
+        unsafe {
+            let original = b"\0" as *const u8;
+            let duped_ptr = yaml_string_duplicate(original);
+            assert!(!duped_ptr.is_null());
+            assert_eq!(*duped_ptr, 0); // Should only contain null terminator
+
+            yaml_free(duped_ptr as *mut c_void);
+        }
+    }
+
+    /// Tests that `yaml_string_join` correctly joins two non-empty string buffers,
+    /// verifying the content and length of the result.
+    #[test]
+    fn test_yaml_string_join() {
+        unsafe {
+            let mut a_start = yaml_malloc(10) as *mut yaml_char_t;
+            let mut a_pointer = a_start;
+            let mut a_end = a_start.add(10);
+
+            let mut b_start = b"test" as *const u8 as *mut yaml_char_t;
+            let mut b_pointer = b_start.add(4);
+            let mut b_end = b_start.add(4);
+
+            yaml_string_join(
+                &mut a_start,
+                &mut a_pointer,
+                &mut a_end,
+                &mut b_start,
+                &mut b_pointer,
+                &mut b_end,
+            );
+
+            assert_eq!(a_pointer.offset_from(a_start), 4);
+            assert_eq!(*a_start, b't');
+            assert_eq!(*a_start.add(1), b'e');
+            assert_eq!(*a_start.add(2), b's');
+            assert_eq!(*a_start.add(3), b't');
+
+            yaml_free(a_start as *mut c_void);
+        }
+    }
+
+    /// Tests that `yaml_string_join` handles joining with an empty buffer correctly,
+    /// ensuring that nothing is copied and pointers remain unchanged.
+    #[test]
+    fn test_yaml_string_join_empty() {
+        unsafe {
+            let mut a_start = yaml_malloc(10) as *mut yaml_char_t;
+            let mut a_pointer = a_start;
+            let mut a_end = a_start.add(10);
+
+            let mut b_start = b"\0" as *const u8 as *mut yaml_char_t;
+            let mut b_pointer = b_start;
+            let mut b_end = b_start;
+
+            yaml_string_join(
+                &mut a_start,
+                &mut a_pointer,
+                &mut a_end,
+                &mut b_start,
+                &mut b_pointer,
+                &mut b_end,
+            );
+
+            assert_eq!(a_pointer.offset_from(a_start), 0); // Nothing should be copied
+
+            yaml_free(a_start as *mut c_void);
+        }
+    }
+
+    /// Tests that `yaml_string_join` can correctly extend the buffer when the initial buffer
+    /// is too small to contain the joined result, ensuring correct reallocation and copying.
+    #[test]
+    fn test_yaml_string_join_extend() {
+        unsafe {
+            let mut a_start = yaml_malloc(2) as *mut yaml_char_t;
+            let mut a_pointer = a_start;
+            let mut a_end = a_start.add(2);
+
+            let mut b_start =
+                b"longer string" as *const u8 as *mut yaml_char_t;
+            let mut b_pointer = b_start.add(12);
+            let mut b_end = b_start.add(12);
+
+            yaml_string_join(
+                &mut a_start,
+                &mut a_pointer,
+                &mut a_end,
+                &mut b_start,
+                &mut b_pointer,
+                &mut b_end,
+            );
+
+            assert!(a_pointer.offset_from(a_start) >= 12);
+            assert_eq!(*a_start, b'l');
+            assert_eq!(*a_start.add(1), b'o');
+            assert_eq!(*a_start.add(2), b'n');
+            assert_eq!(*a_start.add(3), b'g');
+
+            yaml_free(a_start as *mut c_void);
+        }
+    }
+
+    /// Verifies that `yaml_string_duplicate` can accurately duplicate a string that fills
+    /// the entire buffer, ensuring correct memory allocation and duplication integrity.
+    #[test]
+    fn test_yaml_string_duplicate_exact_size() {
+        unsafe {
+            let original = b"exact size\0" as *const u8;
+            let duped_ptr = yaml_string_duplicate(original);
+            assert!(!duped_ptr.is_null());
+            let mut i = 0;
+            while *original.add(i) != 0 {
+                assert_eq!(*original.add(i), *duped_ptr.add(i));
+                i += 1;
+            }
+            assert_eq!(*duped_ptr.add(i), 0); // Null terminator
+
+            yaml_free(duped_ptr as *mut c_void);
+        }
+    }
+
+    /// Ensures that `yaml_string_join` properly handles cases where the buffer is exactly
+    /// full, confirming that the join operation completes without overflow.
+    #[test]
+    fn test_yaml_string_join_full_buffer() {
+        unsafe {
+            let mut a_start = yaml_malloc(4) as *mut yaml_char_t;
+            let mut a_pointer = a_start;
+            let mut a_end = a_start.add(4);
+
+            let mut b_start = b"full" as *const u8 as *mut yaml_char_t;
+            let mut b_pointer = b_start.add(4);
+            let mut b_end = b_start.add(4);
+
+            yaml_string_join(
+                &mut a_start,
+                &mut a_pointer,
+                &mut a_end,
+                &mut b_start,
+                &mut b_pointer,
+                &mut b_end,
+            );
+
+            assert_eq!(a_pointer.offset_from(a_start), 4);
+            assert_eq!(*a_start.add(3), b'l');
+
+            yaml_free(a_start as *mut c_void);
+        }
+    }
+
+    /// Confirms that `yaml_string_join` can handle near-full buffer conditions effectively,
+    /// verifying that the content and pointers are correctly managed without overflow.
+    #[test]
+    fn test_yaml_string_join_near_full_buffer() {
+        unsafe {
+            let mut a_start = yaml_malloc(4) as *mut yaml_char_t;
+            let mut a_pointer = a_start;
+            let mut a_end = a_start.add(4);
+            let b_content = b"full\0";
+            let mut b_start = b_content.as_ptr() as *mut yaml_char_t;
+            let mut b_pointer = b_start.add(4); // Point to the end of the string
+            let mut b_end = b_start.add(4);
+
+            yaml_string_join(
+                &mut a_start,
+                &mut a_pointer,
+                &mut a_end,
+                &mut b_start,
+                &mut b_pointer,
+                &mut b_end,
+            );
+
+            let offset = a_pointer.offset_from(a_start);
+
+            assert_eq!(
+                offset, 4,
+                "Expected offset to be 4, but got {}",
+                offset
+            );
+            assert_eq!(
+                *a_start.add(3),
+                b'l',
+                "Expected last character to be 'l', but got {}",
+                *a_start.add(3) as char
+            );
+
+            // Verify the contents of the buffer
+            assert_eq!(*a_start.add(0), b'f');
+            assert_eq!(*a_start.add(1), b'u');
+            assert_eq!(*a_start.add(2), b'l');
+            assert_eq!(*a_start.add(3), b'l');
+
+            yaml_free(a_start as *mut c_void);
+        }
+    }
+}

--- a/tests/test_yaml.rs
+++ b/tests/test_yaml.rs
@@ -1,0 +1,391 @@
+#![no_std]
+#![cfg(test)]
+
+use libyml::yaml::*;
+
+// Default value tests
+
+/// Tests the default values of YamlVersionDirectiveT
+#[test]
+fn test_default_yaml_version_directive() {
+    let version_directive = YamlVersionDirectiveT::default();
+    assert_eq!(version_directive.major, 0);
+    assert_eq!(version_directive.minor, 0);
+}
+
+/// Tests the default values of YamlMarkT
+#[test]
+fn test_default_yaml_mark() {
+    let mark = YamlMarkT::default();
+    assert_eq!(mark.index, 0);
+    assert_eq!(mark.line, 0);
+    assert_eq!(mark.column, 0);
+}
+
+/// Tests the default values of YamlEncodingT
+#[test]
+fn test_default_yaml_encoding() {
+    let encoding = YamlEncodingT::default();
+    assert_eq!(encoding, YamlEncodingT::YamlAnyEncoding);
+}
+
+/// Tests the default values of YamlScalarStyleT
+#[test]
+fn test_default_yaml_scalar_style() {
+    let scalar_style = YamlScalarStyleT::default();
+    assert_eq!(scalar_style, YamlScalarStyleT::YamlAnyScalarStyle);
+}
+
+/// Tests the default values of YamlSequenceStyleT
+#[test]
+fn test_default_yaml_sequence_style() {
+    let sequence_style = YamlSequenceStyleT::default();
+    assert_eq!(
+        sequence_style,
+        YamlSequenceStyleT::YamlAnySequenceStyle
+    );
+}
+
+/// Tests the default values of YamlMappingStyleT
+#[test]
+fn test_default_yaml_mapping_style() {
+    let mapping_style = YamlMappingStyleT::default();
+    assert_eq!(mapping_style, YamlMappingStyleT::YamlAnyMappingStyle);
+}
+
+/// Tests the default values of YamlTagDirectiveT
+#[test]
+fn test_default_yaml_tag_directive() {
+    let tag_directive = YamlTagDirectiveT::default();
+    assert!(tag_directive.handle.is_null());
+    assert!(tag_directive.prefix.is_null());
+}
+
+/// Tests the default values of YamlBreakT
+#[test]
+fn test_default_yaml_break() {
+    let line_break = YamlBreakT::default();
+    assert_eq!(line_break, YamlBreakT::YamlAnyBreak);
+}
+
+/// Tests the default values of YamlErrorTypeT
+#[test]
+fn test_default_yaml_error_type() {
+    let error_type = YamlErrorTypeT::default();
+    assert_eq!(error_type, YamlErrorTypeT::YamlNoError);
+}
+
+/// Tests the default values of YamlSimpleKeyT
+#[test]
+fn test_default_yaml_simple_key() {
+    let simple_key = YamlSimpleKeyT::default();
+    assert!(!simple_key.possible);
+    assert!(!simple_key.required);
+    assert_eq!(simple_key.token_number, 0);
+    assert_eq!(simple_key.mark.index, 0);
+    assert_eq!(simple_key.mark.line, 0);
+    assert_eq!(simple_key.mark.column, 0);
+}
+
+/// Tests the default values of YamlEventTypeT
+#[test]
+fn test_default_yaml_event_type() {
+    let event_type = YamlEventTypeT::default();
+    assert_eq!(event_type, YamlEventTypeT::YamlNoEvent);
+}
+
+/// Tests the default values of YamlNodeTypeT
+#[test]
+fn test_default_yaml_node_type() {
+    let node_type = YamlNodeTypeT::default();
+    assert_eq!(node_type, YamlNodeTypeT::YamlNoNode);
+}
+
+/// Tests the default values of YamlParserStateT
+#[test]
+fn test_default_yaml_parser_state() {
+    let parser_state = YamlParserStateT::default();
+    assert_eq!(
+        parser_state,
+        YamlParserStateT::YamlParseStreamStartState
+    );
+}
+
+/// Tests the default values of YamlAliasDataT
+#[test]
+fn test_default_yaml_anchor_data() {
+    let anchor_data = YamlAliasDataT::default();
+    assert!(anchor_data.anchor.is_null());
+    assert_eq!(anchor_data.index, 0);
+    assert_eq!(anchor_data.mark.index, 0);
+    assert_eq!(anchor_data.mark.line, 0);
+    assert_eq!(anchor_data.mark.column, 0);
+}
+
+/// Tests the default values of YamlTokenT
+#[test]
+fn test_default_yaml_token() {
+    let token = YamlTokenT::default();
+    assert_eq!(token.type_, YamlTokenTypeT::YamlNoToken);
+    assert_eq!(token.start_mark.index, 0);
+    assert_eq!(token.start_mark.line, 0);
+    assert_eq!(token.start_mark.column, 0);
+    assert_eq!(token.end_mark.index, 0);
+    assert_eq!(token.end_mark.line, 0);
+    assert_eq!(token.end_mark.column, 0);
+}
+
+/// Tests the default values of YamlEmitterStateT
+#[test]
+fn test_default_yaml_emitter_state() {
+    let emitter_state = YamlEmitterStateT::default();
+    assert_eq!(
+        emitter_state,
+        YamlEmitterStateT::YamlEmitStreamStartState
+    );
+}
+
+// Enum value tests
+
+/// Tests the values of YamlEncodingT enum variants
+#[test]
+fn test_yaml_encoding_values() {
+    assert_eq!(YamlEncodingT::YamlAnyEncoding as u32, 0);
+    assert_eq!(YamlEncodingT::YamlUtf8Encoding as u32, 1);
+    assert_eq!(YamlEncodingT::YamlUtf16leEncoding as u32, 2);
+    assert_eq!(YamlEncodingT::YamlUtf16beEncoding as u32, 3);
+}
+
+/// Tests the values of YamlEventTypeT enum variants
+#[test]
+fn test_yaml_event_type_values() {
+    assert_eq!(YamlEventTypeT::YamlNoEvent as u32, 0);
+    assert_eq!(YamlEventTypeT::YamlStreamStartEvent as u32, 1);
+    assert_eq!(YamlEventTypeT::YamlStreamEndEvent as u32, 2);
+    assert_eq!(YamlEventTypeT::YamlDocumentStartEvent as u32, 3);
+    assert_eq!(YamlEventTypeT::YamlDocumentEndEvent as u32, 4);
+    assert_eq!(YamlEventTypeT::YamlAliasEvent as u32, 5);
+    assert_eq!(YamlEventTypeT::YamlScalarEvent as u32, 6);
+    assert_eq!(YamlEventTypeT::YamlSequenceStartEvent as u32, 7);
+    assert_eq!(YamlEventTypeT::YamlSequenceEndEvent as u32, 8);
+    assert_eq!(YamlEventTypeT::YamlMappingStartEvent as u32, 9);
+    assert_eq!(YamlEventTypeT::YamlMappingEndEvent as u32, 10);
+}
+
+/// Tests the values of YamlScalarStyleT enum variants
+#[test]
+fn test_yaml_scalar_style_values() {
+    assert_eq!(YamlScalarStyleT::YamlAnyScalarStyle as u32, 0);
+    assert_eq!(YamlScalarStyleT::YamlPlainScalarStyle as u32, 1);
+    assert_eq!(YamlScalarStyleT::YamlSingleQuotedScalarStyle as u32, 2);
+    assert_eq!(YamlScalarStyleT::YamlDoubleQuotedScalarStyle as u32, 3);
+    assert_eq!(YamlScalarStyleT::YamlLiteralScalarStyle as u32, 4);
+    assert_eq!(YamlScalarStyleT::YamlFoldedScalarStyle as u32, 5);
+}
+
+/// Tests the values of YamlSequenceStyleT enum variants
+#[test]
+fn test_yaml_sequence_style_values() {
+    assert_eq!(YamlSequenceStyleT::YamlAnySequenceStyle as u32, 0);
+    assert_eq!(YamlSequenceStyleT::YamlBlockSequenceStyle as u32, 1);
+    assert_eq!(YamlSequenceStyleT::YamlFlowSequenceStyle as u32, 2);
+}
+
+/// Tests the values of YamlMappingStyleT enum variants
+#[test]
+fn test_yaml_mapping_style_values() {
+    assert_eq!(YamlMappingStyleT::YamlAnyMappingStyle as u32, 0);
+    assert_eq!(YamlMappingStyleT::YamlBlockMappingStyle as u32, 1);
+    assert_eq!(YamlMappingStyleT::YamlFlowMappingStyle as u32, 2);
+}
+
+/// Tests the values of YamlErrorTypeT enum variants
+#[test]
+fn test_yaml_error_type_values() {
+    assert_eq!(YamlErrorTypeT::YamlNoError as u32, 0);
+    assert_eq!(YamlErrorTypeT::YamlMemoryError as u32, 1);
+    assert_eq!(YamlErrorTypeT::YamlReaderError as u32, 2);
+    assert_eq!(YamlErrorTypeT::YamlScannerError as u32, 3);
+    assert_eq!(YamlErrorTypeT::YamlParserError as u32, 4);
+    assert_eq!(YamlErrorTypeT::YamlComposerError as u32, 5);
+    assert_eq!(YamlErrorTypeT::YamlWriterError as u32, 6);
+    assert_eq!(YamlErrorTypeT::YamlEmitterError as u32, 7);
+}
+
+/// Tests the values of YamlNodeTypeT enum variants
+#[test]
+fn test_yaml_node_type_values() {
+    assert_eq!(YamlNodeTypeT::YamlNoNode as u32, 0);
+    assert_eq!(YamlNodeTypeT::YamlScalarNode as u32, 1);
+    assert_eq!(YamlNodeTypeT::YamlSequenceNode as u32, 2);
+    assert_eq!(YamlNodeTypeT::YamlMappingNode as u32, 3);
+}
+
+/// Tests the values of YamlBreakT enum variants
+#[test]
+fn test_yaml_break_type_values() {
+    assert_eq!(YamlBreakT::YamlAnyBreak as u32, 0);
+    assert_eq!(YamlBreakT::YamlCrBreak as u32, 1);
+    assert_eq!(YamlBreakT::YamlLnBreak as u32, 2);
+    assert_eq!(YamlBreakT::YamlCrlnBreak as u32, 3);
+}
+
+/// Tests the values of YamlParserStateT enum variants
+#[test]
+fn test_yaml_parser_state_values() {
+    assert_eq!(YamlParserStateT::YamlParseStreamStartState as u32, 0);
+    assert_eq!(
+        YamlParserStateT::YamlParseImplicitDocumentStartState as u32,
+        1
+    );
+    assert_eq!(YamlParserStateT::YamlParseDocumentStartState as u32, 2);
+    assert_eq!(
+        YamlParserStateT::YamlParseDocumentContentState as u32,
+        3
+    );
+    assert_eq!(YamlParserStateT::YamlParseDocumentEndState as u32, 4);
+    assert_eq!(YamlParserStateT::YamlParseBlockNodeState as u32, 5);
+    assert_eq!(
+        YamlParserStateT::YamlParseBlockNodeOrIndentlessSequenceState
+            as u32,
+        6
+    );
+    assert_eq!(YamlParserStateT::YamlParseFlowNodeState as u32, 7);
+    assert_eq!(
+        YamlParserStateT::YamlParseBlockSequenceFirstEntryState as u32,
+        8
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseBlockSequenceEntryState as u32,
+        9
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseIndentlessSequenceEntryState as u32,
+        10
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseBlockMappingFirstKeyState as u32,
+        11
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseBlockMappingKeyState as u32,
+        12
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseBlockMappingValueState as u32,
+        13
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseFlowSequenceFirstEntryState as u32,
+        14
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseFlowSequenceEntryState as u32,
+        15
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseFlowSequenceEntryMappingKeyState
+            as u32,
+        16
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseFlowSequenceEntryMappingValueState
+            as u32,
+        17
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseFlowSequenceEntryMappingEndState
+            as u32,
+        18
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseFlowMappingFirstKeyState as u32,
+        19
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseFlowMappingKeyState as u32,
+        20
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseFlowMappingValueState as u32,
+        21
+    );
+    assert_eq!(
+        YamlParserStateT::YamlParseFlowMappingEmptyValueState as u32,
+        22
+    );
+    assert_eq!(YamlParserStateT::YamlParseEndState as u32, 23);
+}
+
+/// Tests the values of YamlEmitterStateT enum variants
+#[test]
+fn test_yaml_emitter_state_values() {
+    assert_eq!(YamlEmitterStateT::YamlEmitStreamStartState as u32, 0);
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitFirstDocumentStartState as u32,
+        1
+    );
+    assert_eq!(YamlEmitterStateT::YamlEmitDocumentStartState as u32, 2);
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitDocumentContentState as u32,
+        3
+    );
+    assert_eq!(YamlEmitterStateT::YamlEmitDocumentEndState as u32, 4);
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitFlowSequenceFirstItemState as u32,
+        5
+    );
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitFlowSequenceItemState as u32,
+        6
+    );
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitFlowMappingFirstKeyState as u32,
+        7
+    );
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitFlowMappingKeyState as u32,
+        8
+    );
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitFlowMappingSimpleValueState as u32,
+        9
+    );
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitFlowMappingValueState as u32,
+        10
+    );
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitBlockSequenceFirstItemState as u32,
+        11
+    );
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitBlockSequenceItemState as u32,
+        12
+    );
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitBlockMappingFirstKeyState as u32,
+        13
+    );
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitBlockMappingKeyState as u32,
+        14
+    );
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitBlockMappingSimpleValueState as u32,
+        15
+    );
+    assert_eq!(
+        YamlEmitterStateT::YamlEmitBlockMappingValueState as u32,
+        16
+    );
+    assert_eq!(YamlEmitterStateT::YamlEmitEndState as u32, 17);
+}
+
+/// Tests the constructor of YamlVersionDirectiveT
+#[test]
+fn test_yaml_version_directive() {
+    let version_directive = YamlVersionDirectiveT::new(1, 2);
+    assert_eq!(version_directive.major, 1);
+    assert_eq!(version_directive.minor, 2);
+}


### PR DESCRIPTION
- docs(libyml): :memo: minor tweaks and versionning
- feat(libyml): :art: decoupling `api.rs` via `document.rs`
- feat(libyml): :sparkles: Add `memory.rs`, macros and unit tests
- feat(libyml): :sparkles: Create a new file called internal.rs for internal helper functions
- feat(libyml): :sparkles: decoupling `api.rs` with `decode.rs`
- fix(libyml): :art: fix clippy warnings
- fix(libyml): :art: fix format issues
- fix(libyml): :art: format code
- fix(libyml): :bug: Add consistent error handling
- fix(libyml): :bug: changes to prevent the segmentation fault
- fix(libyml): :bug: error: unnecessary qualification
- fix(libyml): :bug: fix codecov token
- fix(libyml): :bug: fix error: unnecessary qualification
- fix(libyml): :bug: fix error: unneeded `return` statement
- fix(libyml): :bug: fix error: used `assert_eq!` with a literal bool
- fix(libyml): :bug: fix formatting issues
- fix(libyml): :bug: fix: remove the unnecessary path segments
- fix(libyml): :bug: minor changes on libs management
- refactor(libyml): :art: Implement Default trait for YAML types
- refactor(libyml): :art: decoupling `api.rs` yaml_malloc via `memory.rs`
- refactor(libyml): :art: refactor `api.rs`, decoupling strings functions
- refactor(libyml): :art: refactor yaml_free via `memory.rs`
- refactor(libyml): :art: refactor yaml_realloc via `memory.rs`
- refactor(libyml): :white_check_mark: Enhance and reorganize YAML parser test suite and code
- test(libyml): :white_check_mark: Add more unit tests
- test(libyml): :white_check_mark: Add new tests for `yaml.rs`
- test(libyml): :white_check_mark: Add test_yaml_malloc
- test(libyml): :white_check_mark: add new tests