### PR TITLE
WIP: Try to use native C signedness of char

### DIFF
--- a/src/bin/cstr/mod.rs
+++ b/src/bin/cstr/mod.rs
@@ -1,9 +1,7 @@
 use std::fmt::{self, Display, Write as _};
 use std::slice;
 use std::str;
-
-#[allow(non_camel_case_types)]
-type c_char = i8;
+use core::ffi::c_char;
 
 pub(crate) struct CStr {
     pub(crate) ptr: *const u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,9 @@ use core::mem::size_of;
 /// and low-level operations within LibYML.
 pub mod libc {
     pub use core::ffi::c_void;
+    pub use core::ffi::c_char;
     pub use core::primitive::{
-        i32 as c_int, i64 as c_long, i8 as c_char, u32 as c_uint,
+        i32 as c_int, i64 as c_long, u32 as c_uint,
         u64 as c_ulong, u8 as c_uchar,
     };
 }


### PR DESCRIPTION
On architectures where char is by default unsigned (any of the arm variants, ppc64el, s390x, etc), libyml's tests fail.

You can see this in the debian CI, which shows i386 and amd64 (both of which have signed chars) succeeding and the other architectures failing: https://tracker.debian.org/pkg/rust-libyml

You can see a summary of common debian architecture differences at https://wiki.debian.org/ArchitectureSpecificsMemo#Summary

It seems to me like libyml should probably make use of Rust's ffi alias c_char in order to work correctly on all platforms:

  https://doc.rust-lang.org/core/ffi/type.c_char.html

I don't know whether the concrete patch offered is the right fix or not. I would have opened an issue to just document the concern without offering a half-baked fix, but
https://github.com/sebastienrousseau/libyml appears to not have issues enabled (only pull requests), so i'm phrasing this issue in the form of a pull request.