### PR TITLE
ci: fix docs gate to trigger on master and pass cname

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,9 @@ jobs:
           fail-on-severity: moderate
 
   docs:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     uses: sebastienrousseau/pipelines/.github/workflows/docs.yml@main
     with:
       type: rust
       redirect-crate: libyml
+      cname: doc.libyml.com


### PR DESCRIPTION
Fixes the missing master push trigger so the reusable docs workflow runs and refreshes doc.libyml.com with the v0.0.6 build.